### PR TITLE
Backport attempt pch_gbe from 2.6.38 to 2.6.18

### DIFF
--- a/pch_gbe/Makefile
+++ b/pch_gbe/Makefile
@@ -1,0 +1,38 @@
+# If KERNELRELEASE is defined, the make command using this Makefile has
+# been invoked by the kernel build system and so can use its language.
+# Otherwise, if KERNELRELEASE is null, a make command was issued from
+# the command line. So invoke the kernel build system.
+
+ifeq ($(KERNELRELEASE),)
+
+    # KVERSION should be set in the environment if this
+    # build is not for the currently running kernel.
+    KVERSION ?= $(shell uname -r)
+
+    BUILD_DIR := /lib/modules/${KVERSION}/build
+    PWD := $(shell pwd)
+
+modules:
+	$(MAKE) -C $(BUILD_DIR) M=$(PWD) modules
+
+modules_install:
+	$(MAKE) -C $(BUILD_DIR) M=$(PWD) modules_install
+
+clean:
+	rm -rf *~ *.o .*.cmd *.mod.c *.ko .depend .tmp_versions \
+        modules.order Module.symvers Module.markers
+
+.PHONY: modules modules_install clean
+
+else
+
+# Called from kernel build system -- just declare the module(s).
+
+obj-m += pch_gbe.o
+
+pch_gbe-y := pch_gbe_phy.o pch_gbe_param.o
+pch_gbe-y += pch_gbe_api.o pch_gbe_main.o
+pch_gbe-y += pch_gbe_ethtool.o
+
+endif
+

--- a/pch_gbe/README
+++ b/pch_gbe/README
@@ -1,0 +1,33 @@
+NOTE: This module is not functioning yet !!!
+
+This is a backport attempt for kernel module pch_gbe from kernel 2.6.38
+to 2.6.18-238 (RHEL5 kernel). As far as implemented, the module is
+being built against 2.6.18-238, but in fact when insmod'ding it, a
+kernel panic is the result.
+The modified code in this tree is marked with comments "WN mod".
+
+For compilation, additionally the file include/linux/netdevice.h of
+the 2.6.18 kernel sources was modified. So before calling make, the
+modified netdevice.h in the subdir of this tree should be copied in
+place.
+
+Before testing, the module mii has to be loaded, because pch_gbe is
+based on it.
+When insmod'ding the binary module, the resulting call trace of the
+kernel panic looks about like this:
+
+pch_gbe_probe
+__driver_attach
+pci_device_probe
+driver_probe_device
+__driver_attach
+bus_for_each_dev
+driver_attach
+bus_add_driver
+__pci_register_driver
+pch_gbe_init_module
+sys_init_module
+mii_ethtool_gdet
+dput
+syscall
+

--- a/pch_gbe/include/linux/netdevice.h
+++ b/pch_gbe/include/linux/netdevice.h
@@ -1,0 +1,1621 @@
+/*
+ * INET		An implementation of the TCP/IP protocol suite for the LINUX
+ *		operating system.  INET is implemented using the  BSD Socket
+ *		interface as the means of communication with the user level.
+ *
+ *		Definitions for the Interfaces handler.
+ *
+ * Version:	@(#)dev.h	1.0.10	08/12/93
+ *
+ * Authors:	Ross Biro
+ *		Fred N. van Kempen, <waltje@uWalt.NL.Mugnet.ORG>
+ *		Corey Minyard <wf-rch!minyard@relay.EU.net>
+ *		Donald J. Becker, <becker@cesdis.gsfc.nasa.gov>
+ *		Alan Cox, <Alan.Cox@linux.org>
+ *		Bjorn Ekwall. <bj0rn@blox.se>
+ *              Pekka Riikonen <priikone@poseidon.pspt.fi>
+ *
+ *		This program is free software; you can redistribute it and/or
+ *		modify it under the terms of the GNU General Public License
+ *		as published by the Free Software Foundation; either version
+ *		2 of the License, or (at your option) any later version.
+ *
+ *		Moved to /usr/include/linux for NET3
+ */
+#ifndef _LINUX_NETDEVICE_H
+#define _LINUX_NETDEVICE_H
+
+#include <linux/if.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+
+#ifdef __KERNEL__
+#include <asm/atomic.h>
+#include <asm/cache.h>
+#include <asm/byteorder.h>
+
+/* WN mod */
+#include <linux/netlink.h>
+#include <linux/cache.h>
+#include <linux/skbuff.h>
+
+struct neighbour;
+struct neigh_parms;
+struct sk_buff;
+/* WN mod */
+#include <linux/device.h>
+#include <linux/percpu.h>
+#include <linux/dmaengine.h>
+
+struct divert_blk;
+struct vlan_group;
+struct ethtool_ops;
+struct netpoll_info;
+/* 802.11 specific */
+/* WN mod */
+#define MAX_ADDR_LEN    32              /* Largest hardware address length */
+struct wireless_dev;
+struct netdev_hw_addr {
+        struct list_head        list;
+        unsigned char           addr[MAX_ADDR_LEN];
+        unsigned char           type;
+#define NETDEV_HW_ADDR_T_LAN            1
+#define NETDEV_HW_ADDR_T_SAN            2
+#define NETDEV_HW_ADDR_T_SLAVE          3
+#define NETDEV_HW_ADDR_T_UNICAST        4
+#define NETDEV_HW_ADDR_T_MULTICAST      5
+        bool                    synced;
+        bool                    global_use;
+        int                     refcount;
+        struct rcu_head         rcu_head;
+};
+
+
+struct netdev_hw_addr_list {
+        struct list_head        list;
+        int                     count;
+};
+
+/* WN mod start */
+#define netdev_mc_count(dev) netdev_hw_addr_list_count(&(dev)->mc)
+#define netdev_hw_addr_list_count(l) ((l)->count)
+#define netdev_hw_addr_list_empty(l) (netdev_hw_addr_list_count(l) == 0)
+#define netdev_uc_count(dev) netdev_hw_addr_list_count(&(dev)->uc)
+#define netdev_mc_count(dev) netdev_hw_addr_list_count(&(dev)->mc)
+/* WN mod end */
+
+					/* source back-compat hooks */
+#define SET_ETHTOOL_OPS(netdev,ops) \
+	( (netdev)->ethtool_ops = (ops) )
+
+#define HAVE_ALLOC_NETDEV		/* feature macro: alloc_xxxdev
+					   functions are available. */
+#define HAVE_FREE_NETDEV		/* free_netdev() */
+#define HAVE_NETDEV_PRIV		/* netdev_priv() */
+
+#define NET_XMIT_SUCCESS	0
+#define NET_XMIT_DROP		1	/* skb dropped			*/
+#define NET_XMIT_CN		2	/* congestion notification	*/
+#define NET_XMIT_POLICED	3	/* skb is shot by police	*/
+#define NET_XMIT_BYPASS		4	/* packet does not leave via dequeue;
+					   (TC use only - dev_queue_xmit
+					   returns this as NET_XMIT_SUCCESS) */
+
+/* Backlog congestion levels */
+#define NET_RX_SUCCESS		0   /* keep 'em coming, baby */
+#define NET_RX_DROP		1  /* packet dropped */
+#define NET_RX_CN_LOW		2   /* storm alert, just in case */
+#define NET_RX_CN_MOD		3   /* Storm on its way! */
+#define NET_RX_CN_HIGH		4   /* The storm is here */
+#define NET_RX_BAD		5  /* packet dropped due to kernel error */
+
+#define net_xmit_errno(e)	((e) != NET_XMIT_CN ? -ENOBUFS : 0)
+
+#endif
+
+#define MAX_ADDR_LEN	32		/* Largest hardware address length */
+
+/* Driver transmit return codes */
+//#define NETDEV_TX_OK 0		/* driver took care of packet */
+//#define NETDEV_TX_BUSY 1	/* driver tx path was busy*/
+//#define NETDEV_TX_LOCKED -1	/* driver tx lock was already taken */
+
+/*
+ *	Compute the worst case header length according to the protocols
+ *	used.
+ */
+
+#if !defined(CONFIG_AX25) && !defined(CONFIG_AX25_MODULE) && !defined(CONFIG_TR)
+#define LL_MAX_HEADER	32
+#else
+#if defined(CONFIG_AX25) || defined(CONFIG_AX25_MODULE)
+#define LL_MAX_HEADER	96
+#else
+#define LL_MAX_HEADER	48
+#endif
+#endif
+
+#if !defined(CONFIG_NET_IPIP) && \
+    !defined(CONFIG_IPV6) && !defined(CONFIG_IPV6_MODULE)
+#define MAX_HEADER LL_MAX_HEADER
+#else
+#define MAX_HEADER (LL_MAX_HEADER + 48)
+#endif
+/* Driver transmit return codes */
+#define NETDEV_TX_MASK		0xf0
+
+enum netdev_tx {
+	__NETDEV_TX_MIN	 = INT_MIN,	/* make sure enum is signed */
+	NETDEV_TX_OK	 = 0x00,	/* driver took care of packet */
+	NETDEV_TX_BUSY	 = 0x10,	/* driver tx path was busy*/
+	NETDEV_TX_LOCKED = 0x20,	/* driver tx lock was already taken */
+};
+typedef enum netdev_tx netdev_tx_t;
+struct ifla_vf_info {
+        __u32 vf;
+        __u8 mac[32];
+        __u32 vlan;
+        __u32 qos;
+        __u32 tx_rate;
+};
+
+#define HAVE_NET_DEVICE_OPS
+struct net_device_ops {
+	int			(*ndo_init)(struct net_device *dev);
+	void			(*ndo_uninit)(struct net_device *dev);
+	int			(*ndo_open)(struct net_device *dev);
+	int			(*ndo_stop)(struct net_device *dev);
+	netdev_tx_t		(*ndo_start_xmit) (struct sk_buff *skb,
+						   struct net_device *dev);
+	u16			(*ndo_select_queue)(struct net_device *dev,
+						    struct sk_buff *skb);
+	void			(*ndo_change_rx_flags)(struct net_device *dev,
+						       int flags);
+	void			(*ndo_set_rx_mode)(struct net_device *dev);
+	void			(*ndo_set_multicast_list)(struct net_device *dev);
+	int			(*ndo_set_mac_address)(struct net_device *dev,
+						       void *addr);
+	int			(*ndo_validate_addr)(struct net_device *dev);
+	int			(*ndo_do_ioctl)(struct net_device *dev,
+					        struct ifreq *ifr, int cmd);
+	int			(*ndo_set_config)(struct net_device *dev,
+					          struct ifmap *map);
+	int			(*ndo_change_mtu)(struct net_device *dev,
+						  int new_mtu);
+	int			(*ndo_neigh_setup)(struct net_device *dev,
+						   struct neigh_parms *);
+	void			(*ndo_tx_timeout) (struct net_device *dev);
+
+	struct rtnl_link_stats64* (*ndo_get_stats64)(struct net_device *dev,
+						     struct rtnl_link_stats64 *storage);
+	struct net_device_stats* (*ndo_get_stats)(struct net_device *dev);
+
+	void			(*ndo_vlan_rx_register)(struct net_device *dev,
+						        struct vlan_group *grp);
+	void			(*ndo_vlan_rx_add_vid)(struct net_device *dev,
+						       unsigned short vid);
+	void			(*ndo_vlan_rx_kill_vid)(struct net_device *dev,
+						        unsigned short vid);
+#ifdef CONFIG_NET_POLL_CONTROLLER
+	void                    (*ndo_poll_controller)(struct net_device *dev);
+	int			(*ndo_netpoll_setup)(struct net_device *dev,
+						     struct netpoll_info *info);
+	void			(*ndo_netpoll_cleanup)(struct net_device *dev);
+#endif
+	int			(*ndo_set_vf_mac)(struct net_device *dev,
+						  int queue, u8 *mac);
+	int			(*ndo_set_vf_vlan)(struct net_device *dev,
+						   int queue, u16 vlan, u8 qos);
+	int			(*ndo_set_vf_tx_rate)(struct net_device *dev,
+						      int vf, int rate);
+	int			(*ndo_get_vf_config)(struct net_device *dev,
+						     int vf,
+						     struct ifla_vf_info *ivf);
+	int			(*ndo_set_vf_port)(struct net_device *dev,
+						   int vf,
+						   struct nlattr *port[]);
+	int			(*ndo_get_vf_port)(struct net_device *dev,
+						   int vf, struct sk_buff *skb);
+#if defined(CONFIG_FCOE) || defined(CONFIG_FCOE_MODULE)
+	int			(*ndo_fcoe_enable)(struct net_device *dev);
+	int			(*ndo_fcoe_disable)(struct net_device *dev);
+	int			(*ndo_fcoe_ddp_setup)(struct net_device *dev,
+						      u16 xid,
+						      struct scatterlist *sgl,
+						      unsigned int sgc);
+	int			(*ndo_fcoe_ddp_done)(struct net_device *dev,
+						     u16 xid);
+#define NETDEV_FCOE_WWNN 0
+#define NETDEV_FCOE_WWPN 1
+	int			(*ndo_fcoe_get_wwn)(struct net_device *dev,
+						    u64 *wwn, int type);
+#endif
+};
+/*
+ *	Network device statistics. Akin to the 2.0 ether stats but
+ *	with byte counters.
+ */
+
+struct net_device_stats
+{
+	unsigned long	rx_packets;		/* total packets received	*/
+	unsigned long	tx_packets;		/* total packets transmitted	*/
+	unsigned long	rx_bytes;		/* total bytes received 	*/
+	unsigned long	tx_bytes;		/* total bytes transmitted	*/
+	unsigned long	rx_errors;		/* bad packets received		*/
+	unsigned long	tx_errors;		/* packet transmit problems	*/
+	unsigned long	rx_dropped;		/* no space in linux buffers	*/
+	unsigned long	tx_dropped;		/* no space available in linux	*/
+	unsigned long	multicast;		/* multicast packets received	*/
+	unsigned long	collisions;
+
+	/* detailed rx_errors: */
+	unsigned long	rx_length_errors;
+	unsigned long	rx_over_errors;		/* receiver ring buff overflow	*/
+	unsigned long	rx_crc_errors;		/* recved pkt with crc error	*/
+	unsigned long	rx_frame_errors;	/* recv'd frame alignment error */
+	unsigned long	rx_fifo_errors;		/* recv'r fifo overrun		*/
+	unsigned long	rx_missed_errors;	/* receiver missed packet	*/
+
+	/* detailed tx_errors */
+	unsigned long	tx_aborted_errors;
+	unsigned long	tx_carrier_errors;
+	unsigned long	tx_fifo_errors;
+	unsigned long	tx_heartbeat_errors;
+	unsigned long	tx_window_errors;
+
+	/* for cslip etc */
+	unsigned long	rx_compressed;
+	unsigned long	tx_compressed;
+};
+
+
+/* Media selection options. */
+enum {
+        IF_PORT_UNKNOWN = 0,
+        IF_PORT_10BASE2,
+        IF_PORT_10BASET,
+        IF_PORT_AUI,
+        IF_PORT_100BASET,
+        IF_PORT_100BASETX,
+        IF_PORT_100BASEFX
+};
+
+#ifdef __KERNEL__
+
+#include <linux/cache.h>
+#include <linux/skbuff.h>
+
+struct neighbour;
+struct neigh_parms;
+struct sk_buff;
+
+struct netif_rx_stats
+{
+	unsigned total;
+	unsigned dropped;
+	unsigned time_squeeze;
+	unsigned cpu_collision;
+};
+
+DECLARE_PER_CPU(struct netif_rx_stats, netdev_rx_stat);
+
+
+/*
+ *	We tag multicasts with these structures.
+ */
+
+struct dev_mc_list
+{
+	struct dev_mc_list	*next;
+	__u8			dmi_addr[MAX_ADDR_LEN];
+	unsigned char		dmi_addrlen;
+	int			dmi_users;
+	int			dmi_gusers;
+};
+
+#define netdev_hw_addr_list_count(l) ((l)->count)
+#define netdev_hw_addr_list_empty(l) (netdev_hw_addr_list_count(l) == 0)
+#define netdev_hw_addr_list_for_each(ha, l) \
+        list_for_each_entry(ha, &(l)->list, list)
+
+#define netdev_uc_count(dev) netdev_hw_addr_list_count(&(dev)->uc)
+#define netdev_uc_empty(dev) netdev_hw_addr_list_empty(&(dev)->uc)
+#define netdev_for_each_uc_addr(ha, dev) \
+        netdev_hw_addr_list_for_each(ha, &(dev)->uc)
+
+#define netdev_mc_count(dev) netdev_hw_addr_list_count(&(dev)->mc)
+#define netdev_mc_empty(dev) netdev_hw_addr_list_empty(&(dev)->mc)
+#define netdev_for_each_mc_addr(ha, dev) \
+        netdev_hw_addr_list_for_each(ha, &(dev)->mc)
+/* WN mod: commented out the next two lines
+#define netdev_for_each_mc_addr(mcl, dev) \
+	for (mcl = (dev)->mc_list; mcl; mcl = mcl->next) */
+
+struct hh_cache
+{
+	struct hh_cache *hh_next;	/* Next entry			     */
+	atomic_t	hh_refcnt;	/* number of users                   */
+	unsigned short  hh_type;	/* protocol identifier, f.e ETH_P_IP
+                                         *  NOTE:  For VLANs, this will be the
+                                         *  encapuslated type. --BLG
+                                         */
+	int		hh_len;		/* length of header */
+	int		(*hh_output)(struct sk_buff *skb);
+	rwlock_t	hh_lock;
+
+	/* cached hardware header; allow for machine alignment needs.        */
+#define HH_DATA_MOD	16
+#define HH_DATA_OFF(__len) \
+	(HH_DATA_MOD - (((__len - 1) & (HH_DATA_MOD - 1)) + 1))
+#define HH_DATA_ALIGN(__len) \
+	(((__len)+(HH_DATA_MOD-1))&~(HH_DATA_MOD - 1))
+	unsigned long	hh_data[HH_DATA_ALIGN(LL_MAX_HEADER) / sizeof(long)];
+};
+
+/* Reserve HH_DATA_MOD byte aligned hard_header_len, but at least that much.
+ * Alternative is:
+ *   dev->hard_header_len ? (dev->hard_header_len +
+ *                           (HH_DATA_MOD - 1)) & ~(HH_DATA_MOD - 1) : 0
+ *
+ * We could use other alignment values, but we must maintain the
+ * relationship HH alignment <= LL alignment.
+ */
+#define LL_RESERVED_SPACE(dev) \
+	(((dev)->hard_header_len&~(HH_DATA_MOD - 1)) + HH_DATA_MOD)
+#define LL_RESERVED_SPACE_EXTRA(dev,extra) \
+	((((dev)->hard_header_len+extra)&~(HH_DATA_MOD - 1)) + HH_DATA_MOD)
+
+/* These flag bits are private to the generic network queueing
+ * layer, they may not be explicitly referenced by any other
+ * code.
+ */
+
+enum netdev_state_t
+{
+	__LINK_STATE_XOFF=0,
+	__LINK_STATE_START,
+	__LINK_STATE_PRESENT,
+	__LINK_STATE_SCHED,
+	__LINK_STATE_NOCARRIER,
+	__LINK_STATE_RX_SCHED,
+	__LINK_STATE_LINKWATCH_PENDING,
+	__LINK_STATE_DORMANT,
+	__LINK_STATE_QDISC_RUNNING,
+	__LINK_STATE_NETPOLL
+};
+
+
+/*
+ * This structure holds at boot time configured netdevice settings. They
+ * are then used in the device probing.
+ */
+struct netdev_boot_setup {
+	char name[IFNAMSIZ];
+	struct ifmap map;
+};
+#define NETDEV_BOOT_SETUP_MAX 8
+
+extern int __init netdev_boot_setup(char *str);
+/* WN mod */
+enum {
+        NAPI_STATE_SCHED,       /* Poll is scheduled */
+        NAPI_STATE_DISABLE,     /* Disable pending */
+        NAPI_STATE_NPSVC,       /* Netpoll - don't dequeue from poll_list */
+};
+
+/* WN mod */
+struct napi_struct {
+	/* The poll_list must only be managed by the entity which
+	 * changes the state of the NAPI_STATE_SCHED bit.  This means
+	 * whoever atomically sets that bit can add this napi_struct
+	 * to the per-cpu poll_list, and whoever clears that bit
+	 * can remove from the list right before clearing the bit.
+	 */
+	struct list_head	poll_list;
+
+	unsigned long		state;
+	int			weight;
+	int			(*poll)(struct napi_struct *, int);
+#ifdef CONFIG_NETPOLL
+	spinlock_t		poll_lock;
+	int			poll_owner;
+#endif
+
+	unsigned int		gro_count;
+
+	struct net_device	*dev;
+	struct list_head	dev_list;
+	struct sk_buff		*gro_list;
+	struct sk_buff		*skb;
+};
+
+enum {
+	GRO_MERGED,
+	GRO_MERGED_FREE,
+	GRO_HELD,
+	GRO_NORMAL,
+	GRO_DROP,
+};
+
+
+/*
+ *	The DEVICE structure.
+ *	Actually, this whole structure is a big mistake.  It mixes I/O
+ *	data with strictly "high-level" data, and it has to know about
+ *	almost every data structure used in the INET module.
+ *
+ *	FIXME: cleanup struct net_device such that network protocol info
+ *	moves out.
+ */
+struct net_device
+{
+
+	/*
+	 * This is the first field of the "visible" part of this structure
+	 * (i.e. as seen by users in the "Space.c" file).  It is the name
+	 * the interface.
+	 */
+	char			name[IFNAMSIZ];
+	/* device name hash chain */
+	struct hlist_node	name_hlist;
+
+	/*
+	 *	I/O specific fields
+	 *	FIXME: Merge these and struct ifmap into one
+	 */
+	unsigned long		mem_end;	/* shared mem end	*/
+	unsigned long		mem_start;	/* shared mem start	*/
+	unsigned long		base_addr;	/* device I/O address	*/
+	unsigned int		irq;		/* device IRQ number	*/
+
+	/*
+	 *	Some hardware also needs these fields, but they are not
+	 *	part of the usual set specified in Space.c.
+	 */
+
+	unsigned char		if_port;	/* Selectable AUI, TP,..*/
+	unsigned char		dma;		/* DMA channel		*/
+
+	unsigned long		state;
+
+	struct net_device	*next;
+
+	/* The device initialization function. Called only once. */
+	int			(*init)(struct net_device *dev);
+
+	/* ------- Fields preinitialized in Space.c finish here ------- */
+
+	/* Net device features */
+	unsigned long		features;
+#define NETIF_F_SG		1	/* Scatter/gather IO. */
+#define NETIF_F_IP_CSUM		2	/* Can checksum only TCP/UDP over IPv4. */
+#define NETIF_F_NO_CSUM		4	/* Does not require checksum. F.e. loopack. */
+#define NETIF_F_HW_CSUM		8	/* Can checksum all the packets. */
+#define NETIF_F_IPV6_CSUM	16	/* Can checksum TCP/UDP over IPV6 */
+#define NETIF_F_HIGHDMA		32	/* Can DMA to high memory. */
+#define NETIF_F_FRAGLIST	64	/* Scatter/gather IO. */
+#define NETIF_F_HW_VLAN_TX	128	/* Transmit VLAN hw acceleration */
+#define NETIF_F_HW_VLAN_RX	256	/* Receive VLAN hw acceleration */
+#define NETIF_F_HW_VLAN_FILTER	512	/* Receive filtering on VLAN */
+#define NETIF_F_VLAN_CHALLENGED	1024	/* Device cannot handle VLAN packets */
+#define NETIF_F_GSO		2048	/* Enable software GSO. */
+#define NETIF_F_LLTX		4096	/* LockLess TX */
+#define NETIF_F_GRO		16384	/* Generic receive offload */
+#define NETIF_F_LRO		32768	/* large receive offload */
+
+/* Go to the end of the bit field and count backwards when adding new entries
+ * so we don't cause the calculated fields below to shift.  Also don't forget
+ * to update GSO_MASK below to exclude added bits */
+#define NETIF_F_VLAN_TSO	1 << 31	/* Supports TSO for VLANs */
+#define NETIF_F_VLAN_CSUM	1 << 30	/* Supports TX checksumming for VLANs */
+
+	/* Segmentation offload features */
+#define NETIF_F_GSO_SHIFT	16
+#define NETIF_F_GSO_MASK	0x3fff0000
+#define NETIF_F_TSO		(SKB_GSO_TCPV4 << NETIF_F_GSO_SHIFT)
+#define NETIF_F_UFO		(SKB_GSO_UDP << NETIF_F_GSO_SHIFT)
+#define NETIF_F_GSO_ROBUST	(SKB_GSO_DODGY << NETIF_F_GSO_SHIFT)
+#define NETIF_F_TSO_ECN		(SKB_GSO_TCP_ECN << NETIF_F_GSO_SHIFT)
+#define NETIF_F_TSO6		(SKB_GSO_TCPV6 << NETIF_F_GSO_SHIFT)
+
+	/* List of features with software fallbacks. */
+#define NETIF_F_GSO_SOFTWARE	(NETIF_F_TSO | NETIF_F_TSO_ECN | NETIF_F_TSO6)
+
+#define NETIF_F_GEN_CSUM	(NETIF_F_NO_CSUM | NETIF_F_HW_CSUM)
+#define NETIF_F_ALL_CSUM	(NETIF_F_IP_CSUM | NETIF_F_GEN_CSUM)
+
+	/*
+	 * If one device supports one of these features, then enable them
+	 * for all in netdev_increment_features.
+	 */
+#define NETIF_F_ONE_FOR_ALL	(NETIF_F_GSO_SOFTWARE | NETIF_F_GSO_ROBUST | \
+				 NETIF_F_SG | NETIF_F_HIGHDMA | \
+				 NETIF_F_FRAGLIST)
+
+	struct net_device	*next_sched;
+
+	/* Interface index. Unique device identifier	*/
+	int			ifindex;
+	int			iflink;
+
+
+	struct net_device_stats* (*get_stats)(struct net_device *dev);
+	struct iw_statistics*	(*get_wireless_stats)(struct net_device *dev);
+	/* WN mod (just the next line) */
+	struct net_device_stats stats;
+
+	const struct net_device_ops *netdev_ops;
+
+	/* List of functions to handle Wireless Extensions (instead of ioctl).
+	 * See <net/iw_handler.h> for details. Jean II */
+	const struct iw_handler_def *	wireless_handlers;
+	/* Instance data managed by the core of Wireless Extensions. */
+	struct iw_public_data *	wireless_data;
+
+	/* pending config used by cfg80211/wext compat code only */
+	void *cfg80211_wext_pending_config;
+
+	struct ethtool_ops *ethtool_ops;
+
+	/* WN mod (next two lines) */
+        struct netdev_hw_addr_list      uc;     /* Unicast mac addresses */
+        struct netdev_hw_addr_list      mc;     /* Multicast mac addresses */
+
+	/*
+	 * This marks the end of the "visible" part of the structure. All
+	 * fields hereafter are internal to the system, and may change at
+	 * will (read: may be cleaned up at will).
+	 */
+
+
+	unsigned int		flags;	/* interface flags (a la BSD)	*/
+	unsigned short		gflags;
+        unsigned short          priv_flags; /* Like 'flags' but invisible to userspace. */
+	unsigned short		padded;	/* How much padding added by alloc_netdev() */
+
+	unsigned char		operstate; /* RFC2863 operstate */
+	unsigned char		link_mode; /* mapping policy to operstate */
+
+	unsigned		mtu;	/* interface MTU value		*/
+	unsigned short		type;	/* interface hardware type	*/
+	unsigned short		hard_header_len;	/* hardware hdr length	*/
+
+	struct net_device	*master; /* Pointer to master device of a group,
+					  * which this device is member of.
+					  */
+
+	/* Interface address info. */
+	unsigned char		perm_addr[MAX_ADDR_LEN]; /* permanent hw address */
+	unsigned char		addr_len;	/* hardware address length	*/
+	unsigned short          dev_id;		/* for shared network cards */
+
+	struct dev_mc_list	*mc_list;	/* Multicast mac addresses	*/
+	int			mc_count;	/* Number of installed mcasts	*/
+	int			promiscuity;
+	int			allmulti;
+
+
+	/* Protocol specific pointers */
+
+	void 			*atalk_ptr;	/* AppleTalk link 	*/
+	void			*ip_ptr;	/* IPv4 specific data	*/
+	void                    *dn_ptr;        /* DECnet specific data */
+	void                    *ip6_ptr;       /* IPv6 specific data */
+	void			*ec_ptr;	/* Econet specific data	*/
+	void			*ax25_ptr;	/* AX.25 specific data */
+#ifndef __GENKSYMS__
+	struct wireless_dev	*ieee80211_ptr;	/* IEEE 802.11 specific data */
+#else
+	void			*ieee80211_ptr;	/* IEEE 802.11 specific data */
+#endif
+
+/*
+ * Cache line mostly used on receive path (including eth_type_trans())
+ */
+	struct list_head	poll_list ____cacheline_aligned_in_smp;
+					/* Link to poll list	*/
+
+	int			(*poll) (struct net_device *dev, int *quota);
+	int			quota;
+	int			weight;
+	unsigned long		last_rx;	/* Time of last Rx	*/
+	/* Interface address info used in eth_type_trans() */
+	unsigned char		dev_addr[MAX_ADDR_LEN];	/* hw address, (before bcast
+							because most packets are unicast) */
+
+	unsigned char		broadcast[MAX_ADDR_LEN];	/* hw bcast add	*/
+
+/*
+ * Cache line mostly used on queue transmit path (qdisc)
+ */
+	/* device queue lock */
+	spinlock_t		queue_lock ____cacheline_aligned_in_smp;
+	struct Qdisc		*qdisc;
+	struct Qdisc		*qdisc_sleeping;
+	struct list_head	qdisc_list;
+	unsigned long		tx_queue_len;	/* Max frames per queue allowed */
+
+	/* Partially transmitted GSO packet. */
+	struct sk_buff		*gso_skb;
+
+	/* ingress path synchronizer */
+	spinlock_t		ingress_lock;
+	struct Qdisc		*qdisc_ingress;
+
+/*
+ * One part is mostly used on xmit path (device)
+ */
+	/* hard_start_xmit synchronizer */
+	spinlock_t		_xmit_lock ____cacheline_aligned_in_smp;
+	/* cpu id of processor entered to hard_start_xmit or -1,
+	   if nobody entered there.
+	 */
+	int			xmit_lock_owner;
+	void			*priv;	/* pointer to private data	*/
+	int			(*hard_start_xmit) (struct sk_buff *skb,
+						    struct net_device *dev);
+	/* These may be needed for future network-power-down code. */
+	unsigned long		trans_start;	/* Time (in jiffies) of last Tx	*/
+
+	int			watchdog_timeo; /* used by dev_watchdog() */
+	struct timer_list	watchdog_timer;
+
+/*
+ * refcnt is a very hot point, so align it on SMP
+ */
+	/* Number of references to this device */
+	atomic_t		refcnt ____cacheline_aligned_in_smp;
+
+	/* delayed register/unregister */
+	struct list_head	todo_list;
+	/* device index hash chain */
+	struct hlist_node	index_hlist;
+
+	/* register/unregister state machine */
+	enum { NETREG_UNINITIALIZED=0,
+	       NETREG_REGISTERED,	/* completed register_netdevice */
+	       NETREG_UNREGISTERING,	/* called unregister_netdevice */
+	       NETREG_UNREGISTERED,	/* completed unregister todo */
+	       NETREG_RELEASED,		/* called free_netdev */
+	} reg_state;
+
+	/* Called after device is detached from network. */
+	void			(*uninit)(struct net_device *dev);
+	/* Called after last user reference disappears. */
+	void			(*destructor)(struct net_device *dev);
+
+	/* Pointers to interface service routines.	*/
+	int			(*open)(struct net_device *dev);
+	int			(*stop)(struct net_device *dev);
+#define HAVE_NETDEV_POLL
+	int			(*hard_header) (struct sk_buff *skb,
+						struct net_device *dev,
+						unsigned short type,
+						void *daddr,
+						void *saddr,
+						unsigned len);
+	int			(*rebuild_header)(struct sk_buff *skb);
+#define HAVE_MULTICAST
+	void			(*set_multicast_list)(struct net_device *dev);
+#define HAVE_SET_MAC_ADDR
+	int			(*set_mac_address)(struct net_device *dev,
+						   void *addr);
+#define HAVE_PRIVATE_IOCTL
+	int			(*do_ioctl)(struct net_device *dev,
+					    struct ifreq *ifr, int cmd);
+#define HAVE_SET_CONFIG
+	int			(*set_config)(struct net_device *dev,
+					      struct ifmap *map);
+#define HAVE_HEADER_CACHE
+	int			(*hard_header_cache)(struct neighbour *neigh,
+						     struct hh_cache *hh);
+	void			(*header_cache_update)(struct hh_cache *hh,
+						       struct net_device *dev,
+						       unsigned char *  haddr);
+#define HAVE_CHANGE_MTU
+	int			(*change_mtu)(struct net_device *dev, int new_mtu);
+
+#define HAVE_TX_TIMEOUT
+	void			(*tx_timeout) (struct net_device *dev);
+
+	void			(*vlan_rx_register)(struct net_device *dev,
+						    struct vlan_group *grp);
+	void			(*vlan_rx_add_vid)(struct net_device *dev,
+						   unsigned short vid);
+	void			(*vlan_rx_kill_vid)(struct net_device *dev,
+						    unsigned short vid);
+
+	int			(*hard_header_parse)(struct sk_buff *skb,
+						     unsigned char *haddr);
+	int			(*neigh_setup)(struct net_device *dev, struct neigh_parms *);
+#ifdef CONFIG_NETPOLL
+	struct netpoll_info	*npinfo;
+#endif
+#ifdef CONFIG_NET_POLL_CONTROLLER
+	void                    (*poll_controller)(struct net_device *dev);
+#endif
+
+	/* bridge stuff */
+	struct net_bridge_port	*br_port;
+
+#ifdef CONFIG_NET_DIVERT
+	/* this will get initialized at each interface type init routine */
+	struct divert_blk	*divert;
+#endif /* CONFIG_NET_DIVERT */
+
+	/* class/net/name entry */
+	struct class_device	class_dev;
+	/* space for optional statistics and wireless sysfs groups */
+	struct attribute_group  *sysfs_groups[3];
+#ifndef __GENKSYMS__
+	/*
+	 * Private data size is limited to 64kB
+	 */
+#define NETDEV_PRIV_LEN_MAX	0X0000FFFF
+	unsigned short priv_len;
+#endif
+};
+
+/*
+ * struct net_device can't be modified without breaking ABI, so we
+ * add net_device_extended to the end in alloc_netdev.  Anything that
+ * needs to be added to a net_device can be appended here
+ */
+struct ipv6_devconf_extensions {
+	s32 disable_ipv6;
+	s32 accept_dad;
+};
+
+struct ipv4_devconf_extensions {
+	int accept_local;
+};
+
+struct net_device_extended {
+	struct ipv4_devconf_extensions ipv4_devconf_ext;
+	struct ipv6_devconf_extensions ipv6_devconf_ext;
+};
+
+extern struct ipv4_devconf_extensions ipv4_devconf_ext;
+
+
+#define	NETDEV_ALIGN		32
+#define	NETDEV_ALIGN_CONST	(NETDEV_ALIGN - 1)
+
+static inline void *netdev_priv(struct net_device *dev)
+{
+	return (char *)dev + ((sizeof(struct net_device)
+					+ NETDEV_ALIGN_CONST)
+				& ~NETDEV_ALIGN_CONST);
+}
+
+static inline struct net_device_extended *dev_extended(struct net_device *dev)
+{
+	if (!(dev->priv_flags & IFF_EXTENDED))
+		return NULL;
+	return (struct net_device_extended *) ((char *) netdev_priv(dev) +
+		((dev->priv_len + NETDEV_ALIGN_CONST) & ~NETDEV_ALIGN_CONST));
+}
+
+#define SET_MODULE_OWNER(dev) do { } while (0)
+/* Set the sysfs physical device reference for the network logical device
+ * if set prior to registration will cause a symlink during initialization.
+ */
+#define SET_NETDEV_DEV(net, pdev)	((net)->class_dev.dev = (pdev))
+/* WN mod */
+/**
+ *	netif_napi_add - initialize a napi context
+ *	@dev:  network device
+ *	@napi: napi context
+ *	@poll: polling function
+ *	@weight: default weight
+ *
+ * netif_napi_add() must be used to initialize a napi context prior to calling
+ * *any* of the other napi related functions.
+ */
+void netif_napi_add(struct net_device *dev, struct napi_struct *napi,
+		    int (*poll)(struct napi_struct *, int), int weight);
+
+/**
+ *      napi_disable - prevent NAPI from scheduling
+ *      @n: napi context
+ *
+ * Stop NAPI from being scheduled on this context.
+ * Waits till any outstanding processing completes.
+ */
+static inline void napi_disable(struct napi_struct *n)
+{
+        set_bit(NAPI_STATE_DISABLE, &n->state);
+        while (test_and_set_bit(NAPI_STATE_SCHED, &n->state))
+                msleep(1);
+        clear_bit(NAPI_STATE_DISABLE, &n->state);
+}
+
+/**
+ *      napi_enable - enable NAPI scheduling
+ *      @n: napi context
+ *
+ * Resume NAPI from being scheduled on this context.
+ * Must be paired with napi_disable.
+ */
+static inline void napi_enable(struct napi_struct *n)
+{
+        BUG_ON(!test_bit(NAPI_STATE_SCHED, &n->state));
+        smp_mb__before_clear_bit();
+        clear_bit(NAPI_STATE_SCHED, &n->state);
+}
+
+/* WN mod */
+struct napi_gro_cb {
+	/* Virtual address of skb_shinfo(skb)->frags[0].page + offset. */
+	void *frag0;
+
+	/* Length of frag0. */
+	unsigned int frag0_len;
+
+	/* This indicates where we are processing relative to skb->data. */
+	int data_offset;
+
+	/* This is non-zero if the packet may be of the same flow. */
+	int same_flow;
+
+	/* This is non-zero if the packet cannot be merged with the new skb. */
+	int flush;
+
+	/* Number of segments aggregated. */
+	int count;
+
+	/* Free the skb? */
+	int free;
+};
+
+#define NAPI_GRO_CB(skb) ((struct napi_gro_cb *)(skb)->cb)
+
+struct gro_packet_type {
+	__be16			type;	/* This is really htons(ether_type). */
+	struct net_device	*dev;	/* NULL is wildcarded here	     */
+	struct sk_buff		**(*gro_receive)(struct sk_buff **head,
+					       struct sk_buff *skb);
+	int			(*gro_complete)(struct sk_buff *skb);
+	struct list_head	list;
+};
+
+struct packet_type {
+	__be16			type;	/* This is really htons(ether_type). */
+	struct net_device	*dev;	/* NULL is wildcarded here	     */
+	int			(*func) (struct sk_buff *,
+					 struct net_device *,
+					 struct packet_type *,
+					 struct net_device *);
+	struct sk_buff		*(*gso_segment)(struct sk_buff *skb,
+						int features);
+	int			(*gso_send_check)(struct sk_buff *skb);
+	void			*af_packet_priv;
+	struct list_head	list;
+};
+
+typedef int (*lro_func_t)(struct net_device *);
+
+#include <linux/interrupt.h>
+#include <linux/notifier.h>
+
+extern struct net_device		loopback_dev;		/* The loopback */
+extern struct net_device		*dev_base;		/* All devices */
+extern rwlock_t				dev_base_lock;		/* Device list lock */
+
+extern int 			netdev_boot_setup_check(struct net_device *dev);
+extern unsigned long		netdev_boot_base(const char *prefix, int unit);
+extern struct net_device    *dev_getbyhwaddr(unsigned short type, char *hwaddr);
+extern struct net_device *dev_getfirstbyhwtype(unsigned short type);
+extern void		dev_add_pack(struct packet_type *pt);
+extern void		dev_remove_pack(struct packet_type *pt);
+extern void		__dev_remove_pack(struct packet_type *pt);
+extern void		dev_add_pack_gro(struct gro_packet_type *pt);
+extern void		dev_remove_pack_gro(struct gro_packet_type *pt);
+
+extern struct net_device	*dev_get_by_flags(unsigned short flags,
+						  unsigned short mask);
+extern struct net_device	*dev_get_by_name(const char *name);
+extern struct net_device	*__dev_get_by_name(const char *name);
+extern int		dev_alloc_name(struct net_device *dev, const char *name);
+extern int		dev_open(struct net_device *dev);
+extern int		dev_close(struct net_device *dev);
+extern void		dev_disable_lro(struct net_device *dev);
+extern int 	register_lro_netdev(struct net_device *dev, lro_func_t func);
+extern void 	unregister_lro_netdev(struct net_device *dev);
+extern int		dev_queue_xmit(struct sk_buff *skb);
+extern int		register_netdevice(struct net_device *dev);
+extern int		unregister_netdevice(struct net_device *dev);
+extern void		free_netdev(struct net_device *dev);
+extern void		synchronize_net(void);
+extern int 		register_netdevice_notifier(struct notifier_block *nb);
+extern int		unregister_netdevice_notifier(struct notifier_block *nb);
+extern int		call_netdevice_notifiers(unsigned long val, void *v);
+extern struct net_device	*dev_get_by_index(int ifindex);
+extern struct net_device	*__dev_get_by_index(int ifindex);
+extern int		dev_restart(struct net_device *dev);
+#ifdef CONFIG_NETPOLL_TRAP
+extern int		netpoll_trap(void);
+#endif
+
+extern int	       skb_gro_receive(struct sk_buff **head,
+				       struct sk_buff *skb);
+extern void	       skb_gro_reset_offset(struct sk_buff *skb);
+
+static inline unsigned int skb_gro_offset(const struct sk_buff *skb)
+{
+	return NAPI_GRO_CB(skb)->data_offset;
+}
+
+static inline unsigned int skb_gro_len(const struct sk_buff *skb)
+{
+	return skb->len - NAPI_GRO_CB(skb)->data_offset;
+}
+
+static inline void skb_gro_pull(struct sk_buff *skb, unsigned int len)
+{
+	NAPI_GRO_CB(skb)->data_offset += len;
+}
+
+static inline void *skb_gro_header_fast(struct sk_buff *skb,
+					unsigned int offset)
+{
+	return NAPI_GRO_CB(skb)->frag0 + offset;
+}
+
+static inline int skb_gro_header_hard(struct sk_buff *skb, unsigned int hlen)
+{
+	return NAPI_GRO_CB(skb)->frag0_len < hlen;
+}
+
+static inline void *skb_gro_header_slow(struct sk_buff *skb, unsigned int hlen,
+					unsigned int offset)
+{
+	NAPI_GRO_CB(skb)->frag0 = NULL;
+	NAPI_GRO_CB(skb)->frag0_len = 0;
+	return pskb_may_pull(skb, hlen) ? skb->data + offset : NULL;
+}
+
+static inline void *skb_gro_mac_header(struct sk_buff *skb)
+{
+	return NAPI_GRO_CB(skb)->frag0 ?: skb_mac_header(skb);
+}
+
+static inline void *skb_gro_network_header(struct sk_buff *skb)
+{
+	return (NAPI_GRO_CB(skb)->frag0 ?: skb->data) +
+	       skb_network_offset(skb);
+}
+
+typedef int gifconf_func_t(struct net_device * dev, char __user * bufptr, int len);
+extern int		register_gifconf(unsigned int family, gifconf_func_t * gifconf);
+static inline int unregister_gifconf(unsigned int family)
+{
+	return register_gifconf(family, NULL);
+}
+
+/*
+ * Incoming packets are placed on per-cpu queues so that
+ * no locking is needed.
+ */
+
+struct softnet_data
+{
+	struct net_device	*output_queue;
+	struct sk_buff_head	input_pkt_queue;
+	struct list_head	poll_list;
+	struct sk_buff		*completion_queue;
+
+	struct net_device	backlog_dev;	/* Sorry. 8) */
+#ifdef CONFIG_NET_DMA
+	struct dma_chan		*net_dma;
+#endif
+};
+
+DECLARE_PER_CPU(struct softnet_data,softnet_data);
+
+#define HAVE_NETIF_QUEUE
+
+extern void __netif_schedule(struct net_device *dev);
+
+static inline void netif_schedule(struct net_device *dev)
+{
+	if (!test_bit(__LINK_STATE_XOFF, &dev->state))
+		__netif_schedule(dev);
+}
+
+static inline void netif_start_queue(struct net_device *dev)
+{
+	clear_bit(__LINK_STATE_XOFF, &dev->state);
+}
+
+static inline void netif_wake_queue(struct net_device *dev)
+{
+#ifdef CONFIG_NETPOLL_TRAP
+	if (netpoll_trap())
+		return;
+#endif
+	if (test_and_clear_bit(__LINK_STATE_XOFF, &dev->state))
+		__netif_schedule(dev);
+}
+
+static inline void netif_stop_queue(struct net_device *dev)
+{
+#ifdef CONFIG_NETPOLL_TRAP
+	if (netpoll_trap())
+		return;
+#endif
+	set_bit(__LINK_STATE_XOFF, &dev->state);
+}
+
+static inline int netif_queue_stopped(const struct net_device *dev)
+{
+	return test_bit(__LINK_STATE_XOFF, &dev->state);
+}
+
+static inline int netif_running(const struct net_device *dev)
+{
+	return test_bit(__LINK_STATE_START, &dev->state);
+}
+
+/* Use this variant when it is known for sure that it
+ * is executing from interrupt context.
+ */
+static inline void dev_kfree_skb_irq(struct sk_buff *skb)
+{
+	if (atomic_dec_and_test(&skb->users)) {
+		struct softnet_data *sd;
+		unsigned long flags;
+
+		local_irq_save(flags);
+		sd = &__get_cpu_var(softnet_data);
+		skb->next = sd->completion_queue;
+		sd->completion_queue = skb;
+		raise_softirq_irqoff(NET_TX_SOFTIRQ);
+		local_irq_restore(flags);
+	}
+}
+
+/* Use this variant in places where it could be invoked
+ * either from interrupt or non-interrupt context.
+ */
+extern void dev_kfree_skb_any(struct sk_buff *skb);
+
+#define HAVE_NETIF_RX 1
+extern int		netif_rx(struct sk_buff *skb);
+extern int		netif_rx_ni(struct sk_buff *skb);
+#define HAVE_NETIF_RECEIVE_SKB 1
+extern int		netif_receive_skb(struct sk_buff *skb);
+extern void		napi_gro_flush(struct napi_struct *napi);
+extern int		dev_gro_receive(struct napi_struct *napi,
+					struct sk_buff *skb);
+extern int		napi_skb_finish(int ret, struct sk_buff *skb);
+extern int		napi_gro_receive(struct napi_struct *napi,
+					 struct sk_buff *skb);
+extern void		napi_reuse_skb(struct napi_struct *napi,
+				       struct sk_buff *skb);
+extern struct sk_buff *	napi_get_frags(struct napi_struct *napi);
+extern int		napi_frags_finish(struct napi_struct *napi,
+					  struct sk_buff *skb, int ret);
+extern struct sk_buff *	napi_frags_skb(struct napi_struct *napi);
+extern int		napi_gro_frags(struct napi_struct *napi);
+
+static inline void napi_free_frags(struct napi_struct *napi)
+{
+	kfree_skb(napi->skb);
+	napi->skb = NULL;
+}
+
+extern int		dev_valid_name(const char *name);
+extern int		dev_ioctl(unsigned int cmd, void __user *);
+extern int		dev_ethtool(struct ifreq *);
+extern unsigned		dev_get_flags(const struct net_device *);
+extern int		dev_change_flags(struct net_device *, unsigned);
+extern int		dev_change_name(struct net_device *, char *);
+extern int		dev_set_mtu(struct net_device *, int);
+extern int		dev_set_mac_address(struct net_device *,
+					    struct sockaddr *);
+extern int		dev_hard_start_xmit(struct sk_buff *skb,
+					    struct net_device *dev);
+
+extern void		dev_init(void);
+
+extern int		netdev_budget;
+
+/* Called by rtnetlink.c:rtnl_unlock() */
+extern void netdev_run_todo(void);
+
+static inline void dev_put(struct net_device *dev)
+{
+	atomic_dec(&dev->refcnt);
+}
+
+static inline void dev_hold(struct net_device *dev)
+{
+	atomic_inc(&dev->refcnt);
+}
+
+/* Carrier loss detection, dial on demand. The functions netif_carrier_on
+ * and _off may be called from IRQ context, but it is caller
+ * who is responsible for serialization of these calls.
+ *
+ * The name carrier is inappropriate, these functions should really be
+ * called netif_lowerlayer_*() because they represent the state of any
+ * kind of lower layer not just hardware media.
+ */
+
+extern void linkwatch_fire_event(struct net_device *dev);
+
+static inline int netif_carrier_ok(const struct net_device *dev)
+{
+	return !test_bit(__LINK_STATE_NOCARRIER, &dev->state);
+}
+
+extern void __netdev_watchdog_up(struct net_device *dev);
+
+extern void netif_carrier_on(struct net_device *dev);
+
+extern void netif_carrier_off(struct net_device *dev);
+
+static inline void netif_dormant_on(struct net_device *dev)
+{
+	if (!test_and_set_bit(__LINK_STATE_DORMANT, &dev->state))
+		linkwatch_fire_event(dev);
+}
+
+static inline void netif_dormant_off(struct net_device *dev)
+{
+	if (test_and_clear_bit(__LINK_STATE_DORMANT, &dev->state))
+		linkwatch_fire_event(dev);
+}
+
+static inline int netif_dormant(const struct net_device *dev)
+{
+	return test_bit(__LINK_STATE_DORMANT, &dev->state);
+}
+
+
+static inline int netif_oper_up(const struct net_device *dev) {
+	return (dev->operstate == IF_OPER_UP ||
+		dev->operstate == IF_OPER_UNKNOWN /* backward compat */);
+}
+
+/* Hot-plugging. */
+static inline int netif_device_present(struct net_device *dev)
+{
+	return test_bit(__LINK_STATE_PRESENT, &dev->state);
+}
+
+extern void netif_device_detach(struct net_device *dev);
+
+extern void netif_device_attach(struct net_device *dev);
+
+/*
+ * Network interface message level settings
+ */
+#define HAVE_NETIF_MSG 1
+
+enum {
+	NETIF_MSG_DRV		= 0x0001,
+	NETIF_MSG_PROBE		= 0x0002,
+	NETIF_MSG_LINK		= 0x0004,
+	NETIF_MSG_TIMER		= 0x0008,
+	NETIF_MSG_IFDOWN	= 0x0010,
+	NETIF_MSG_IFUP		= 0x0020,
+	NETIF_MSG_RX_ERR	= 0x0040,
+	NETIF_MSG_TX_ERR	= 0x0080,
+	NETIF_MSG_TX_QUEUED	= 0x0100,
+	NETIF_MSG_INTR		= 0x0200,
+	NETIF_MSG_TX_DONE	= 0x0400,
+	NETIF_MSG_RX_STATUS	= 0x0800,
+	NETIF_MSG_PKTDATA	= 0x1000,
+	NETIF_MSG_HW		= 0x2000,
+	NETIF_MSG_WOL		= 0x4000,
+};
+
+#define netif_msg_drv(p)	((p)->msg_enable & NETIF_MSG_DRV)
+#define netif_msg_probe(p)	((p)->msg_enable & NETIF_MSG_PROBE)
+#define netif_msg_link(p)	((p)->msg_enable & NETIF_MSG_LINK)
+#define netif_msg_timer(p)	((p)->msg_enable & NETIF_MSG_TIMER)
+#define netif_msg_ifdown(p)	((p)->msg_enable & NETIF_MSG_IFDOWN)
+#define netif_msg_ifup(p)	((p)->msg_enable & NETIF_MSG_IFUP)
+#define netif_msg_rx_err(p)	((p)->msg_enable & NETIF_MSG_RX_ERR)
+#define netif_msg_tx_err(p)	((p)->msg_enable & NETIF_MSG_TX_ERR)
+#define netif_msg_tx_queued(p)	((p)->msg_enable & NETIF_MSG_TX_QUEUED)
+#define netif_msg_intr(p)	((p)->msg_enable & NETIF_MSG_INTR)
+#define netif_msg_tx_done(p)	((p)->msg_enable & NETIF_MSG_TX_DONE)
+#define netif_msg_rx_status(p)	((p)->msg_enable & NETIF_MSG_RX_STATUS)
+#define netif_msg_pktdata(p)	((p)->msg_enable & NETIF_MSG_PKTDATA)
+#define netif_msg_hw(p)		((p)->msg_enable & NETIF_MSG_HW)
+#define netif_msg_wol(p)	((p)->msg_enable & NETIF_MSG_WOL)
+
+static inline u32 netif_msg_init(int debug_value, int default_msg_enable_bits)
+{
+	/* use default */
+	if (debug_value < 0 || debug_value >= (sizeof(u32) * 8))
+		return default_msg_enable_bits;
+	if (debug_value == 0)	/* no output */
+		return 0;
+	/* set low N bits */
+	return (1 << debug_value) - 1;
+}
+
+/* Test if receive needs to be scheduled */
+static inline int __netif_rx_schedule_prep(struct net_device *dev)
+{
+	return !test_and_set_bit(__LINK_STATE_RX_SCHED, &dev->state);
+}
+
+/* Test if receive needs to be scheduled but only if up */
+static inline int netif_rx_schedule_prep(struct net_device *dev)
+{
+	return netif_running(dev) && __netif_rx_schedule_prep(dev);
+}
+
+/* Add interface to tail of rx poll list. This assumes that _prep has
+ * already been called and returned 1.
+ */
+
+extern void __netif_rx_schedule(struct net_device *dev);
+
+/* Try to reschedule poll. Called by irq handler. */
+
+static inline void netif_rx_schedule(struct net_device *dev)
+{
+	if (netif_rx_schedule_prep(dev))
+		__netif_rx_schedule(dev);
+}
+
+/* Try to reschedule poll. Called by dev->poll() after netif_rx_complete().
+ * Do not inline this?
+ */
+static inline int netif_rx_reschedule(struct net_device *dev, int undo)
+{
+	if (netif_rx_schedule_prep(dev)) {
+		unsigned long flags;
+
+		dev->quota += undo;
+
+		local_irq_save(flags);
+		list_add_tail(&dev->poll_list, &__get_cpu_var(softnet_data).poll_list);
+		__raise_softirq_irqoff(NET_RX_SOFTIRQ);
+		local_irq_restore(flags);
+		return 1;
+	}
+	return 0;
+}
+
+/* Remove interface from poll list: it must be in the poll list
+ * on current cpu. This primitive is called by dev->poll(), when
+ * it completes the work. The device cannot be out of poll list at this
+ * moment, it is BUG().
+ */
+static inline void netif_rx_complete(struct net_device *dev)
+{
+	unsigned long flags;
+
+	/* do not change poll list if called from netpoll */
+	if (test_bit(__LINK_STATE_NETPOLL, &dev->state))
+		return;
+	local_irq_save(flags);
+	BUG_ON(!test_bit(__LINK_STATE_RX_SCHED, &dev->state));
+	list_del(&dev->poll_list);
+	smp_mb__before_clear_bit();
+	clear_bit(__LINK_STATE_RX_SCHED, &dev->state);
+	local_irq_restore(flags);
+}
+
+static inline void napi_complete(struct napi_struct *n)
+{
+	napi_gro_flush(n);
+	netif_rx_complete(n->dev);
+}
+
+static inline void netif_poll_disable(struct net_device *dev)
+{
+	while (test_and_set_bit(__LINK_STATE_RX_SCHED, &dev->state))
+		/* No hurry. */
+		schedule_timeout_interruptible(1);
+}
+
+static inline void netif_poll_enable(struct net_device *dev)
+{
+	clear_bit(__LINK_STATE_RX_SCHED, &dev->state);
+}
+
+/* same as netif_rx_complete, except that local_irq_save(flags)
+ * has already been issued
+ */
+static inline void __netif_rx_complete(struct net_device *dev)
+{
+	/* do not change poll list if called from netpoll */
+	if (test_bit(__LINK_STATE_NETPOLL, &dev->state))
+		return;
+	BUG_ON(!test_bit(__LINK_STATE_RX_SCHED, &dev->state));
+	list_del(&dev->poll_list);
+	smp_mb__before_clear_bit();
+	clear_bit(__LINK_STATE_RX_SCHED, &dev->state);
+}
+
+static inline void netif_tx_lock(struct net_device *dev)
+{
+	spin_lock(&dev->_xmit_lock);
+	dev->xmit_lock_owner = smp_processor_id();
+}
+
+static inline void netif_tx_lock_bh(struct net_device *dev)
+{
+	spin_lock_bh(&dev->_xmit_lock);
+	dev->xmit_lock_owner = smp_processor_id();
+}
+
+static inline int netif_tx_trylock(struct net_device *dev)
+{
+	int ok = spin_trylock(&dev->_xmit_lock);
+	if (likely(ok))
+		dev->xmit_lock_owner = smp_processor_id();
+	return ok;
+}
+
+static inline void netif_tx_unlock(struct net_device *dev)
+{
+	dev->xmit_lock_owner = -1;
+	spin_unlock(&dev->_xmit_lock);
+}
+
+static inline void netif_tx_unlock_bh(struct net_device *dev)
+{
+	dev->xmit_lock_owner = -1;
+	spin_unlock_bh(&dev->_xmit_lock);
+}
+
+static inline void netif_tx_disable(struct net_device *dev)
+{
+	netif_tx_lock_bh(dev);
+	netif_stop_queue(dev);
+	netif_tx_unlock_bh(dev);
+}
+
+/* These functions live elsewhere (drivers/net/net_init.c, but related) */
+
+extern void		ether_setup(struct net_device *dev);
+
+/* Support for loadable net-drivers */
+extern struct net_device *alloc_netdev(int sizeof_priv, const char *name,
+				       void (*setup)(struct net_device *));
+extern int		register_netdev(struct net_device *dev);
+extern void		unregister_netdev(struct net_device *dev);
+/* Functions used for multicast support */
+extern void		dev_mc_upload(struct net_device *dev);
+extern int 		dev_mc_delete(struct net_device *dev, void *addr, int alen, int all);
+extern int		dev_mc_add(struct net_device *dev, void *addr, int alen, int newonly);
+extern void		dev_mc_discard(struct net_device *dev);
+extern void		dev_set_promiscuity(struct net_device *dev, int inc);
+extern void		dev_set_allmulti(struct net_device *dev, int inc);
+extern void		netdev_state_change(struct net_device *dev);
+extern void		netdev_bonding_change(struct net_device *dev);
+extern void		netdev_features_change(struct net_device *dev);
+/* Load a device via the kmod */
+extern void		dev_load(const char *name);
+extern void		dev_mcast_init(void);
+extern int		netdev_max_backlog;
+extern int		weight_p;
+extern int		netdev_set_master(struct net_device *dev, struct net_device *master);
+extern int skb_checksum_help(struct sk_buff *skb, int inward);
+extern struct sk_buff *skb_gso_segment(struct sk_buff *skb, int features);
+#ifdef CONFIG_BUG
+extern void netdev_rx_csum_fault(struct net_device *dev);
+#else
+static inline void netdev_rx_csum_fault(struct net_device *dev)
+{
+}
+#endif
+/* rx skb timestamps */
+extern void		net_enable_timestamp(void);
+extern void		net_disable_timestamp(void);
+
+#ifdef CONFIG_PROC_FS
+extern void *dev_seq_start(struct seq_file *seq, loff_t *pos);
+extern void *dev_seq_next(struct seq_file *seq, void *v, loff_t *pos);
+extern void dev_seq_stop(struct seq_file *seq, void *v);
+#endif
+
+extern int netdev_class_create_file(struct class_attribute *class_attr);
+extern void netdev_class_remove_file(struct class_attribute *class_attr);
+
+extern void linkwatch_run_queue(void);
+
+unsigned long netdev_increment_features(unsigned long all, unsigned long one,
+					unsigned long mask);
+unsigned long netdev_fix_features(unsigned long features, const char *name);
+
+static inline int net_gso_ok(int features, int gso_type)
+{
+	int feature = gso_type << NETIF_F_GSO_SHIFT;
+	return (features & feature) == feature;
+}
+
+static inline int skb_gso_ok(struct sk_buff *skb, int features)
+{
+	return net_gso_ok(features, skb_shinfo(skb)->gso_type) &&
+	       (!skb_shinfo(skb)->frag_list || (features & NETIF_F_FRAGLIST));
+}
+
+static inline int netif_needs_gso(struct net_device *dev, struct sk_buff *skb)
+{
+	return skb_is_gso(skb) &&
+	       (!skb_gso_ok(skb, dev->features) ||
+		unlikely(skb->ip_summed != CHECKSUM_HW));
+}
+
+static inline void skb_bond_set_mac_by_master(struct sk_buff *skb,
+					      struct net_device *master)
+{
+	if (skb->pkt_type == PACKET_HOST) {
+		u16 *dest = (u16 *) eth_hdr(skb)->h_dest;
+
+		memcpy(dest, master->dev_addr, ETH_ALEN);
+	}
+}
+
+/* On bonding slaves other than the currently active slave, suppress
+ * duplicates except for 802.3ad ETH_P_SLOW, alb non-mcast/bcast, and
+ * ARP on active-backup slaves with arp_validate enabled.
+ */
+static inline int skb_bond_should_drop(struct sk_buff *skb)
+{
+	struct net_device *dev = skb->dev;
+	struct net_device *master = dev->master;
+
+	if (master) {
+		if (master->priv_flags & IFF_MASTER_ARPMON)
+			dev->last_rx = jiffies;
+
+		if ((master->priv_flags & IFF_MASTER_ALB) && master->br_port) {
+			/* Do address unmangle. The local destination address
+			 * will be always the one master has. Provides the right
+			 * functionality in a bridge.
+			 */
+			skb_bond_set_mac_by_master(skb, master);
+		}
+
+		if (dev->priv_flags & IFF_SLAVE_INACTIVE) {
+			if ((dev->priv_flags & IFF_SLAVE_NEEDARP) &&
+			    skb->protocol == __constant_htons(ETH_P_ARP))
+				return 0;
+
+			if (master->priv_flags & IFF_MASTER_ALB) {
+				if (skb->pkt_type != PACKET_BROADCAST &&
+				    skb->pkt_type != PACKET_MULTICAST)
+					return 0;
+			}
+			if (master->priv_flags & IFF_MASTER_8023AD &&
+			    skb->protocol == __constant_htons(ETH_P_SLOW))
+				return 0;
+
+			return 1;
+		}
+	}
+	return 0;
+}
+
+#define to_net_dev(class) container_of(class, struct net_device, class_dev)
+
+/* Logging, debugging and troubleshooting/diagnostic helpers. */
+
+/* netdev_printk helpers, similar to dev_printk */
+
+static inline const char *netdev_name(const struct net_device *dev)
+{
+	if (dev->reg_state != NETREG_REGISTERED)
+		return "(unregistered net_device)";
+	return dev->name;
+}
+
+#define netdev_printk(level, netdev, format, args...)		\
+	dev_printk(level, (netdev)->class_dev.dev,		\
+		   "%s: " format,				\
+		   netdev_name(netdev), ##args)
+
+#define netdev_emerg(dev, format, args...)			\
+	netdev_printk(KERN_EMERG, dev, format, ##args)
+#define netdev_alert(dev, format, args...)			\
+	netdev_printk(KERN_ALERT, dev, format, ##args)
+#define netdev_crit(dev, format, args...)			\
+	netdev_printk(KERN_CRIT, dev, format, ##args)
+#define netdev_err(dev, format, args...)			\
+	netdev_printk(KERN_ERR, dev, format, ##args)
+#define netdev_warn(dev, format, args...)			\
+	netdev_printk(KERN_WARNING, dev, format, ##args)
+#define netdev_notice(dev, format, args...)			\
+	netdev_printk(KERN_NOTICE, dev, format, ##args)
+#define netdev_info(dev, format, args...)			\
+	netdev_printk(KERN_INFO, dev, format, ##args)
+
+#if defined(DEBUG)
+#define netdev_dbg(__dev, format, args...)			\
+	netdev_printk(KERN_DEBUG, __dev, format, ##args)
+#else
+#define netdev_dbg(__dev, format, args...)			\
+({								\
+	if (0)							\
+		netdev_printk(KERN_DEBUG, __dev, format, ##args); \
+	0;							\
+})
+#endif
+
+#if defined(VERBOSE_DEBUG)
+#define netdev_vdbg	netdev_dbg
+#else
+
+#define netdev_vdbg(dev, format, args...)			\
+({								\
+	if (0)							\
+		netdev_printk(KERN_DEBUG, dev, format, ##args);	\
+	0;							\
+})
+#endif
+
+/*
+ * netdev_WARN() acts like dev_printk(), but with the key difference
+ * of using a WARN/WARN_ON to get the message out, including the
+ * file/line information and a backtrace.
+ */
+#define netdev_WARN(dev, format, args...)			\
+	WARN(1, "netdevice: %s\n" format, netdev_name(dev), ##args);
+
+/* netif printk helpers, similar to netdev_printk */
+
+#define netif_printk(priv, type, level, dev, fmt, args...)	\
+do {					  			\
+	if (netif_msg_##type(priv))				\
+		netdev_printk(level, (dev), fmt, ##args);	\
+} while (0)
+
+#define netif_level(level, priv, type, dev, fmt, args...)	\
+do {								\
+	if (netif_msg_##type(priv))				\
+		netdev_##level(dev, fmt, ##args);		\
+} while (0)
+
+#define netif_emerg(priv, type, dev, fmt, args...)		\
+	netif_level(emerg, priv, type, dev, fmt, ##args)
+#define netif_alert(priv, type, dev, fmt, args...)		\
+	netif_level(alert, priv, type, dev, fmt, ##args)
+#define netif_crit(priv, type, dev, fmt, args...)		\
+	netif_level(crit, priv, type, dev, fmt, ##args)
+#define netif_err(priv, type, dev, fmt, args...)		\
+	netif_level(err, priv, type, dev, fmt, ##args)
+#define netif_warn(priv, type, dev, fmt, args...)		\
+	netif_level(warn, priv, type, dev, fmt, ##args)
+#define netif_notice(priv, type, dev, fmt, args...)		\
+	netif_level(notice, priv, type, dev, fmt, ##args)
+#define netif_info(priv, type, dev, fmt, args...)		\
+	netif_level(info, priv, type, dev, fmt, ##args)
+
+#if defined(DEBUG)
+#define netif_dbg(priv, type, dev, format, args...)		\
+	netif_printk(priv, type, KERN_DEBUG, dev, format, ##args)
+#else
+#define netif_dbg(priv, type, dev, format, args...)			\
+({									\
+	if (0)								\
+		netif_printk(priv, type, KERN_DEBUG, dev, format, ##args); \
+	0;								\
+})
+#endif
+
+#if defined(VERBOSE_DEBUG)
+#define netif_vdbg	netif_dbg
+#else
+#define netif_vdbg(priv, type, dev, format, args...)		\
+({								\
+	if (0)							\
+		netif_printk(priv, type, KERN_DEBUG, dev, format, ##args); \
+	0;							\
+})
+#endif
+
+#endif /* __KERNEL__ */
+
+#endif	/* _LINUX_DEV_H */

--- a/pch_gbe/pch_gbe.h
+++ b/pch_gbe/pch_gbe.h
@@ -1,0 +1,659 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#ifndef _PCH_GBE_H_
+#define _PCH_GBE_H_
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/mii.h>
+#include <linux/delay.h>
+#include <linux/pci.h>
+#include <linux/netdevice.h>
+#include <linux/etherdevice.h>
+#include <linux/ethtool.h>
+#include <linux/vmalloc.h>
+#include <net/ip.h>
+#include <net/tcp.h>
+#include <net/udp.h>
+
+/**
+ * pch_gbe_regs_mac_adr - Structure holding values of mac address registers
+ * @high	Denotes the 1st to 4th byte from the initial of MAC address
+ * @low		Denotes the 5th to 6th byte from the initial of MAC address
+ */
+struct pch_gbe_regs_mac_adr {
+	u32 high;
+	u32 low;
+};
+/**
+ * pch_udc_regs - Structure holding values of MAC registers
+ */
+struct pch_gbe_regs {
+	u32 INT_ST;
+	u32 INT_EN;
+	u32 MODE;
+	u32 RESET;
+	u32 TCPIP_ACC;
+	u32 EX_LIST;
+	u32 INT_ST_HOLD;
+	u32 PHY_INT_CTRL;
+	u32 MAC_RX_EN;
+	u32 RX_FCTRL;
+	u32 PAUSE_REQ;
+	u32 RX_MODE;
+	u32 TX_MODE;
+	u32 RX_FIFO_ST;
+	u32 TX_FIFO_ST;
+	u32 TX_FID;
+	u32 TX_RESULT;
+	u32 PAUSE_PKT1;
+	u32 PAUSE_PKT2;
+	u32 PAUSE_PKT3;
+	u32 PAUSE_PKT4;
+	u32 PAUSE_PKT5;
+	u32 reserve[2];
+	struct pch_gbe_regs_mac_adr mac_adr[16];
+	u32 ADDR_MASK;
+	u32 MIIM;
+	u32 MAC_ADDR_LOAD;
+	u32 RGMII_ST;
+	u32 RGMII_CTRL;
+	u32 reserve3[3];
+	u32 DMA_CTRL;
+	u32 reserve4[3];
+	u32 RX_DSC_BASE;
+	u32 RX_DSC_SIZE;
+	u32 RX_DSC_HW_P;
+	u32 RX_DSC_HW_P_HLD;
+	u32 RX_DSC_SW_P;
+	u32 reserve5[3];
+	u32 TX_DSC_BASE;
+	u32 TX_DSC_SIZE;
+	u32 TX_DSC_HW_P;
+	u32 TX_DSC_HW_P_HLD;
+	u32 TX_DSC_SW_P;
+	u32 reserve6[3];
+	u32 RX_DMA_ST;
+	u32 TX_DMA_ST;
+	u32 reserve7[2];
+	u32 WOL_ST;
+	u32 WOL_CTRL;
+	u32 WOL_ADDR_MASK;
+};
+
+/* Interrupt Status */
+/* Interrupt Status Hold */
+/* Interrupt Enable */
+#define PCH_GBE_INT_RX_DMA_CMPLT  0x00000001 /* Receive DMA Transfer Complete */
+#define PCH_GBE_INT_RX_VALID      0x00000002 /* MAC Normal Receive Complete */
+#define PCH_GBE_INT_RX_FRAME_ERR  0x00000004 /* Receive frame error */
+#define PCH_GBE_INT_RX_FIFO_ERR   0x00000008 /* Receive FIFO Overflow */
+#define PCH_GBE_INT_RX_DMA_ERR    0x00000010 /* Receive DMA Transfer Error */
+#define PCH_GBE_INT_RX_DSC_EMP    0x00000020 /* Receive Descriptor Empty */
+#define PCH_GBE_INT_TX_CMPLT      0x00000100 /* MAC Transmission Complete */
+#define PCH_GBE_INT_TX_DMA_CMPLT  0x00000200 /* DMA Transfer Complete */
+#define PCH_GBE_INT_TX_FIFO_ERR   0x00000400 /* Transmission FIFO underflow. */
+#define PCH_GBE_INT_TX_DMA_ERR    0x00000800 /* Transmission DMA Error */
+#define PCH_GBE_INT_PAUSE_CMPLT   0x00001000 /* Pause Transmission complete */
+#define PCH_GBE_INT_MIIM_CMPLT    0x00010000 /* MIIM I/F Read completion */
+#define PCH_GBE_INT_PHY_INT       0x00100000 /* Interruption from PHY */
+#define PCH_GBE_INT_WOL_DET       0x01000000 /* Wake On LAN Event detection. */
+#define PCH_GBE_INT_TCPIP_ERR     0x10000000 /* TCP/IP Accelerator Error */
+
+/* Mode */
+#define PCH_GBE_MODE_MII_ETHER      0x00000000  /* GIGA Ethernet Mode [MII] */
+#define PCH_GBE_MODE_GMII_ETHER     0x80000000  /* GIGA Ethernet Mode [GMII] */
+#define PCH_GBE_MODE_HALF_DUPLEX    0x00000000  /* Duplex Mode [half duplex] */
+#define PCH_GBE_MODE_FULL_DUPLEX    0x40000000  /* Duplex Mode [full duplex] */
+#define PCH_GBE_MODE_FR_BST         0x04000000  /* Frame bursting is done */
+
+/* Reset */
+#define PCH_GBE_ALL_RST         0x80000000  /* All reset */
+#define PCH_GBE_TX_RST          0x40000000  /* TX MAC, TX FIFO, TX DMA reset */
+#define PCH_GBE_RX_RST          0x04000000  /* RX MAC, RX FIFO, RX DMA reset */
+
+/* TCP/IP Accelerator Control */
+#define PCH_GBE_EX_LIST_EN      0x00000008  /* External List Enable */
+#define PCH_GBE_RX_TCPIPACC_OFF 0x00000004  /* RX TCP/IP ACC Disabled */
+#define PCH_GBE_TX_TCPIPACC_EN  0x00000002  /* TX TCP/IP ACC Enable */
+#define PCH_GBE_RX_TCPIPACC_EN  0x00000001  /* RX TCP/IP ACC Enable */
+
+/* MAC RX Enable */
+#define PCH_GBE_MRE_MAC_RX_EN   0x00000001      /* MAC Receive Enable */
+
+/* RX Flow Control */
+#define PCH_GBE_FL_CTRL_EN      0x80000000  /* Pause packet is enabled */
+
+/* Pause Packet Request */
+#define PCH_GBE_PS_PKT_RQ       0x80000000  /* Pause packet Request */
+
+/* RX Mode */
+#define PCH_GBE_ADD_FIL_EN      0x80000000  /* Address Filtering Enable */
+/* Multicast Filtering Enable */
+#define PCH_GBE_MLT_FIL_EN      0x40000000
+/* Receive Almost Empty Threshold */
+#define PCH_GBE_RH_ALM_EMP_4    0x00000000      /* 4 words */
+#define PCH_GBE_RH_ALM_EMP_8    0x00004000      /* 8 words */
+#define PCH_GBE_RH_ALM_EMP_16   0x00008000      /* 16 words */
+#define PCH_GBE_RH_ALM_EMP_32   0x0000C000      /* 32 words */
+/* Receive Almost Full Threshold */
+#define PCH_GBE_RH_ALM_FULL_4   0x00000000      /* 4 words */
+#define PCH_GBE_RH_ALM_FULL_8   0x00001000      /* 8 words */
+#define PCH_GBE_RH_ALM_FULL_16  0x00002000      /* 16 words */
+#define PCH_GBE_RH_ALM_FULL_32  0x00003000      /* 32 words */
+/* RX FIFO Read Triger Threshold */
+#define PCH_GBE_RH_RD_TRG_4     0x00000000      /* 4 words */
+#define PCH_GBE_RH_RD_TRG_8     0x00000200      /* 8 words */
+#define PCH_GBE_RH_RD_TRG_16    0x00000400      /* 16 words */
+#define PCH_GBE_RH_RD_TRG_32    0x00000600      /* 32 words */
+#define PCH_GBE_RH_RD_TRG_64    0x00000800      /* 64 words */
+#define PCH_GBE_RH_RD_TRG_128   0x00000A00      /* 128 words */
+#define PCH_GBE_RH_RD_TRG_256   0x00000C00      /* 256 words */
+#define PCH_GBE_RH_RD_TRG_512   0x00000E00      /* 512 words */
+
+/* Receive Descriptor bit definitions */
+#define PCH_GBE_RXD_ACC_STAT_BCAST          0x00000400
+#define PCH_GBE_RXD_ACC_STAT_MCAST          0x00000200
+#define PCH_GBE_RXD_ACC_STAT_UCAST          0x00000100
+#define PCH_GBE_RXD_ACC_STAT_TCPIPOK        0x000000C0
+#define PCH_GBE_RXD_ACC_STAT_IPOK           0x00000080
+#define PCH_GBE_RXD_ACC_STAT_TCPOK          0x00000040
+#define PCH_GBE_RXD_ACC_STAT_IP6ERR         0x00000020
+#define PCH_GBE_RXD_ACC_STAT_OFLIST         0x00000010
+#define PCH_GBE_RXD_ACC_STAT_TYPEIP         0x00000008
+#define PCH_GBE_RXD_ACC_STAT_MACL           0x00000004
+#define PCH_GBE_RXD_ACC_STAT_PPPOE          0x00000002
+#define PCH_GBE_RXD_ACC_STAT_VTAGT          0x00000001
+#define PCH_GBE_RXD_GMAC_STAT_PAUSE         0x0200
+#define PCH_GBE_RXD_GMAC_STAT_MARBR         0x0100
+#define PCH_GBE_RXD_GMAC_STAT_MARMLT        0x0080
+#define PCH_GBE_RXD_GMAC_STAT_MARIND        0x0040
+#define PCH_GBE_RXD_GMAC_STAT_MARNOTMT      0x0020
+#define PCH_GBE_RXD_GMAC_STAT_TLONG         0x0010
+#define PCH_GBE_RXD_GMAC_STAT_TSHRT         0x0008
+#define PCH_GBE_RXD_GMAC_STAT_NOTOCTAL      0x0004
+#define PCH_GBE_RXD_GMAC_STAT_NBLERR        0x0002
+#define PCH_GBE_RXD_GMAC_STAT_CRCERR        0x0001
+
+/* Transmit Descriptor bit definitions */
+#define PCH_GBE_TXD_CTRL_TCPIP_ACC_OFF      0x0008
+#define PCH_GBE_TXD_CTRL_ITAG               0x0004
+#define PCH_GBE_TXD_CTRL_ICRC               0x0002
+#define PCH_GBE_TXD_CTRL_APAD               0x0001
+#define PCH_GBE_TXD_WORDS_SHIFT             2
+#define PCH_GBE_TXD_GMAC_STAT_CMPLT         0x2000
+#define PCH_GBE_TXD_GMAC_STAT_ABT           0x1000
+#define PCH_GBE_TXD_GMAC_STAT_EXCOL         0x0800
+#define PCH_GBE_TXD_GMAC_STAT_SNGCOL        0x0400
+#define PCH_GBE_TXD_GMAC_STAT_MLTCOL        0x0200
+#define PCH_GBE_TXD_GMAC_STAT_CRSER         0x0100
+#define PCH_GBE_TXD_GMAC_STAT_TLNG          0x0080
+#define PCH_GBE_TXD_GMAC_STAT_TSHRT         0x0040
+#define PCH_GBE_TXD_GMAC_STAT_LTCOL         0x0020
+#define PCH_GBE_TXD_GMAC_STAT_TFUNDFLW      0x0010
+#define PCH_GBE_TXD_GMAC_STAT_RTYCNT_MASK   0x000F
+
+/* TX Mode */
+#define PCH_GBE_TM_NO_RTRY     0x80000000 /* No Retransmission */
+#define PCH_GBE_TM_LONG_PKT    0x40000000 /* Long Packt TX Enable */
+#define PCH_GBE_TM_ST_AND_FD   0x20000000 /* Stare and Forward */
+#define PCH_GBE_TM_SHORT_PKT   0x10000000 /* Short Packet TX Enable */
+#define PCH_GBE_TM_LTCOL_RETX  0x08000000 /* Retransmission at Late Collision */
+/* Frame Start Threshold */
+#define PCH_GBE_TM_TH_TX_STRT_4    0x00000000    /* 4 words */
+#define PCH_GBE_TM_TH_TX_STRT_8    0x00004000    /* 8 words */
+#define PCH_GBE_TM_TH_TX_STRT_16   0x00008000    /* 16 words */
+#define PCH_GBE_TM_TH_TX_STRT_32   0x0000C000    /* 32 words */
+/* Transmit Almost Empty Threshold */
+#define PCH_GBE_TM_TH_ALM_EMP_4    0x00000000    /* 4 words */
+#define PCH_GBE_TM_TH_ALM_EMP_8    0x00000800    /* 8 words */
+#define PCH_GBE_TM_TH_ALM_EMP_16   0x00001000    /* 16 words */
+#define PCH_GBE_TM_TH_ALM_EMP_32   0x00001800    /* 32 words */
+#define PCH_GBE_TM_TH_ALM_EMP_64   0x00002000    /* 64 words */
+#define PCH_GBE_TM_TH_ALM_EMP_128  0x00002800    /* 128 words */
+#define PCH_GBE_TM_TH_ALM_EMP_256  0x00003000    /* 256 words */
+#define PCH_GBE_TM_TH_ALM_EMP_512  0x00003800    /* 512 words */
+/* Transmit Almost Full Threshold */
+#define PCH_GBE_TM_TH_ALM_FULL_4   0x00000000    /* 4 words */
+#define PCH_GBE_TM_TH_ALM_FULL_8   0x00000200    /* 8 words */
+#define PCH_GBE_TM_TH_ALM_FULL_16  0x00000400    /* 16 words */
+#define PCH_GBE_TM_TH_ALM_FULL_32  0x00000600    /* 32 words */
+
+/* RX FIFO Status */
+#define PCH_GBE_RF_ALM_FULL     0x80000000  /* RX FIFO is almost full. */
+#define PCH_GBE_RF_ALM_EMP      0x40000000  /* RX FIFO is almost empty. */
+#define PCH_GBE_RF_RD_TRG       0x20000000  /* Become more than RH_RD_TRG. */
+#define PCH_GBE_RF_STRWD        0x1FFE0000  /* The word count of RX FIFO. */
+#define PCH_GBE_RF_RCVING       0x00010000  /* Stored in RX FIFO. */
+
+/* MAC Address Mask */
+#define PCH_GBE_BUSY                0x80000000
+
+/* MIIM  */
+#define PCH_GBE_MIIM_OPER_WRITE     0x04000000
+#define PCH_GBE_MIIM_OPER_READ      0x00000000
+#define PCH_GBE_MIIM_OPER_READY     0x04000000
+#define PCH_GBE_MIIM_PHY_ADDR_SHIFT 21
+#define PCH_GBE_MIIM_REG_ADDR_SHIFT 16
+
+/* RGMII Status */
+#define PCH_GBE_LINK_UP             0x80000008
+#define PCH_GBE_RXC_SPEED_MSK       0x00000006
+#define PCH_GBE_RXC_SPEED_2_5M      0x00000000    /* 2.5MHz */
+#define PCH_GBE_RXC_SPEED_25M       0x00000002    /* 25MHz  */
+#define PCH_GBE_RXC_SPEED_125M      0x00000004    /* 100MHz */
+#define PCH_GBE_DUPLEX_FULL         0x00000001
+
+/* RGMII Control */
+#define PCH_GBE_CRS_SEL             0x00000010
+#define PCH_GBE_RGMII_RATE_125M     0x00000000
+#define PCH_GBE_RGMII_RATE_25M      0x00000008
+#define PCH_GBE_RGMII_RATE_2_5M     0x0000000C
+#define PCH_GBE_RGMII_MODE_GMII     0x00000000
+#define PCH_GBE_RGMII_MODE_RGMII    0x00000002
+#define PCH_GBE_CHIP_TYPE_EXTERNAL  0x00000000
+#define PCH_GBE_CHIP_TYPE_INTERNAL  0x00000001
+
+/* DMA Control */
+#define PCH_GBE_RX_DMA_EN       0x00000002   /* Enables Receive DMA */
+#define PCH_GBE_TX_DMA_EN       0x00000001   /* Enables Transmission DMA */
+
+/* Wake On LAN Status */
+#define PCH_GBE_WLS_BR          0x00000008 /* Broadcas Address */
+#define PCH_GBE_WLS_MLT         0x00000004 /* Multicast Address */
+
+/* The Frame registered in Address Recognizer */
+#define PCH_GBE_WLS_IND         0x00000002
+#define PCH_GBE_WLS_MP          0x00000001 /* Magic packet Address */
+
+/* Wake On LAN Control */
+#define PCH_GBE_WLC_WOL_MODE    0x00010000
+#define PCH_GBE_WLC_IGN_TLONG   0x00000100
+#define PCH_GBE_WLC_IGN_TSHRT   0x00000080
+#define PCH_GBE_WLC_IGN_OCTER   0x00000040
+#define PCH_GBE_WLC_IGN_NBLER   0x00000020
+#define PCH_GBE_WLC_IGN_CRCER   0x00000010
+#define PCH_GBE_WLC_BR          0x00000008
+#define PCH_GBE_WLC_MLT         0x00000004
+#define PCH_GBE_WLC_IND         0x00000002
+#define PCH_GBE_WLC_MP          0x00000001
+
+/* Wake On LAN Address Mask */
+#define PCH_GBE_WLA_BUSY        0x80000000
+
+
+
+/* TX/RX descriptor defines */
+#define PCH_GBE_MAX_TXD                     4096
+#define PCH_GBE_DEFAULT_TXD                  256
+#define PCH_GBE_MIN_TXD                        8
+#define PCH_GBE_MAX_RXD                     4096
+#define PCH_GBE_DEFAULT_RXD                  256
+#define PCH_GBE_MIN_RXD                        8
+
+/* Number of Transmit and Receive Descriptors must be a multiple of 8 */
+#define PCH_GBE_TX_DESC_MULTIPLE               8
+#define PCH_GBE_RX_DESC_MULTIPLE               8
+
+/* Read/Write operation is done through MII Management IF */
+#define PCH_GBE_HAL_MIIM_READ          ((u32)0x00000000)
+#define PCH_GBE_HAL_MIIM_WRITE         ((u32)0x04000000)
+
+/* flow control values */
+#define PCH_GBE_FC_NONE			0
+#define PCH_GBE_FC_RX_PAUSE		1
+#define PCH_GBE_FC_TX_PAUSE		2
+#define PCH_GBE_FC_FULL			3
+#define PCH_GBE_FC_DEFAULT		PCH_GBE_FC_FULL
+
+
+struct pch_gbe_hw;
+/**
+ * struct  pch_gbe_functions - HAL APi function pointer
+ * @get_bus_info:	for pch_gbe_hal_get_bus_info
+ * @init_hw:		for pch_gbe_hal_init_hw
+ * @read_phy_reg:	for pch_gbe_hal_read_phy_reg
+ * @write_phy_reg:	for pch_gbe_hal_write_phy_reg
+ * @reset_phy:		for pch_gbe_hal_phy_hw_reset
+ * @sw_reset_phy:	for pch_gbe_hal_phy_sw_reset
+ * @power_up_phy:	for pch_gbe_hal_power_up_phy
+ * @power_down_phy:	for pch_gbe_hal_power_down_phy
+ * @read_mac_addr:	for pch_gbe_hal_read_mac_addr
+ */
+struct pch_gbe_functions {
+	void (*get_bus_info) (struct pch_gbe_hw *);
+	s32 (*init_hw) (struct pch_gbe_hw *);
+	s32 (*read_phy_reg) (struct pch_gbe_hw *, u32, u16 *);
+	s32 (*write_phy_reg) (struct pch_gbe_hw *, u32, u16);
+	void (*reset_phy) (struct pch_gbe_hw *);
+	void (*sw_reset_phy) (struct pch_gbe_hw *);
+	void (*power_up_phy) (struct pch_gbe_hw *hw);
+	void (*power_down_phy) (struct pch_gbe_hw *hw);
+	s32 (*read_mac_addr) (struct pch_gbe_hw *);
+};
+
+/**
+ * struct pch_gbe_mac_info - MAC infomation
+ * @addr[6]:		Store the MAC address
+ * @fc:			Mode of flow control
+ * @fc_autoneg:		Auto negotiation enable for flow control setting
+ * @tx_fc_enable:	Enable flag of Transmit flow control
+ * @max_frame_size:	Max transmit frame size
+ * @min_frame_size:	Min transmit frame size
+ * @autoneg:		Auto negotiation enable
+ * @link_speed:		Link speed
+ * @link_duplex:	Link duplex
+ */
+struct pch_gbe_mac_info {
+	u8 addr[6];
+	u8 fc;
+	u8 fc_autoneg;
+	u8 tx_fc_enable;
+	u32 max_frame_size;
+	u32 min_frame_size;
+	u8 autoneg;
+	u16 link_speed;
+	u16 link_duplex;
+};
+
+/**
+ * struct pch_gbe_phy_info - PHY infomation
+ * @addr:		PHY address
+ * @id:			PHY's identifier
+ * @revision:		PHY's revision
+ * @reset_delay_us:	HW reset delay time[us]
+ * @autoneg_advertised:	Autoneg advertised
+ */
+struct pch_gbe_phy_info {
+	u32 addr;
+	u32 id;
+	u32 revision;
+	u32 reset_delay_us;
+	u16 autoneg_advertised;
+};
+
+/*!
+ * @ingroup Gigabit Ether driver Layer
+ * @struct  pch_gbe_bus_info
+ * @brief   Bus infomation
+ */
+struct pch_gbe_bus_info {
+	u8 type;
+	u8 speed;
+	u8 width;
+};
+
+/*!
+ * @ingroup Gigabit Ether driver Layer
+ * @struct  pch_gbe_hw
+ * @brief   Hardware infomation
+ */
+struct pch_gbe_hw {
+	void *back;
+
+	struct pch_gbe_regs  __iomem *reg;
+	spinlock_t miim_lock;
+
+	const struct pch_gbe_functions *func;
+	struct pch_gbe_mac_info mac;
+	struct pch_gbe_phy_info phy;
+	struct pch_gbe_bus_info bus;
+};
+
+/**
+ * struct pch_gbe_rx_desc - Receive Descriptor
+ * @buffer_addr:	RX Frame Buffer Address
+ * @tcp_ip_status:	TCP/IP Accelerator Status
+ * @rx_words_eob:	RX word count and Byte position
+ * @gbec_status:	GMAC Status
+ * @dma_status:		DMA Status
+ * @reserved1:		Reserved
+ * @reserved2:		Reserved
+ */
+struct pch_gbe_rx_desc {
+	u32 buffer_addr;
+	u32 tcp_ip_status;
+	u16 rx_words_eob;
+	u16 gbec_status;
+	u8 dma_status;
+	u8 reserved1;
+	u16 reserved2;
+};
+
+/**
+ * struct pch_gbe_tx_desc - Transmit Descriptor
+ * @buffer_addr:	TX Frame Buffer Address
+ * @length:		Data buffer length
+ * @reserved1:		Reserved
+ * @tx_words_eob:	TX word count and Byte position
+ * @tx_frame_ctrl:	TX Frame Control
+ * @dma_status:		DMA Status
+ * @reserved2:		Reserved
+ * @gbec_status:	GMAC Status
+ */
+struct pch_gbe_tx_desc {
+	u32 buffer_addr;
+	u16 length;
+	u16 reserved1;
+	u16 tx_words_eob;
+	u16 tx_frame_ctrl;
+	u8 dma_status;
+	u8 reserved2;
+	u16 gbec_status;
+};
+
+
+/**
+ * struct pch_gbe_buffer - Buffer infomation
+ * @skb:	pointer to a socket buffer
+ * @dma:	DMA address
+ * @time_stamp:	time stamp
+ * @length:	data size
+ */
+struct pch_gbe_buffer {
+	struct sk_buff *skb;
+	dma_addr_t dma;
+	unsigned long time_stamp;
+	u16 length;
+	bool mapped;
+};
+
+/**
+ * struct pch_gbe_tx_ring - tx ring infomation
+ * @tx_lock:	spinlock structs
+ * @desc:	pointer to the descriptor ring memory
+ * @dma:	physical address of the descriptor ring
+ * @size:	length of descriptor ring in bytes
+ * @count:	number of descriptors in the ring
+ * @next_to_use:	next descriptor to associate a buffer with
+ * @next_to_clean:	next descriptor to check for DD status bit
+ * @buffer_info:	array of buffer information structs
+ */
+struct pch_gbe_tx_ring {
+	spinlock_t tx_lock;
+	struct pch_gbe_tx_desc *desc;
+	dma_addr_t dma;
+	unsigned int size;
+	unsigned int count;
+	unsigned int next_to_use;
+	unsigned int next_to_clean;
+	struct pch_gbe_buffer *buffer_info;
+};
+
+/**
+ * struct pch_gbe_rx_ring - rx ring infomation
+ * @desc:	pointer to the descriptor ring memory
+ * @dma:	physical address of the descriptor ring
+ * @size:	length of descriptor ring in bytes
+ * @count:	number of descriptors in the ring
+ * @next_to_use:	next descriptor to associate a buffer with
+ * @next_to_clean:	next descriptor to check for DD status bit
+ * @buffer_info:	array of buffer information structs
+ */
+struct pch_gbe_rx_ring {
+	struct pch_gbe_rx_desc *desc;
+	dma_addr_t dma;
+	unsigned int size;
+	unsigned int count;
+	unsigned int next_to_use;
+	unsigned int next_to_clean;
+	struct pch_gbe_buffer *buffer_info;
+};
+
+/**
+ * struct pch_gbe_hw_stats - Statistics counters collected by the MAC
+ * @rx_packets:		    total packets received
+ * @tx_packets:		    total packets transmitted
+ * @rx_bytes:		    total bytes received
+ * @tx_bytes:		    total bytes transmitted
+ * @rx_errors:		    bad packets received
+ * @tx_errors:		    packet transmit problems
+ * @rx_dropped:		    no space in Linux buffers
+ * @tx_dropped:		    no space available in Linux
+ * @multicast:		    multicast packets received
+ * @collisions:		    collisions
+ * @rx_crc_errors:	    received packet with crc error
+ * @rx_frame_errors:	    received frame alignment error
+ * @rx_alloc_buff_failed:   allocate failure of a receive buffer
+ * @tx_length_errors:	    transmit length error
+ * @tx_aborted_errors:	    transmit aborted error
+ * @tx_carrier_errors:	    transmit carrier error
+ * @tx_timeout_count:	    Number of transmit timeout
+ * @tx_restart_count:	    Number of transmit restert
+ * @intr_rx_dsc_empty_count:	Interrupt count of receive descriptor empty
+ * @intr_rx_frame_err_count:	Interrupt count of receive frame error
+ * @intr_rx_fifo_err_count:	Interrupt count of receive FIFO error
+ * @intr_rx_dma_err_count:	Interrupt count of receive DMA error
+ * @intr_tx_fifo_err_count:	Interrupt count of transmit FIFO error
+ * @intr_tx_dma_err_count:	Interrupt count of transmit DMA error
+ * @intr_tcpip_err_count:	Interrupt count of TCP/IP Accelerator
+ */
+struct pch_gbe_hw_stats {
+	u32 rx_packets;
+	u32 tx_packets;
+	u32 rx_bytes;
+	u32 tx_bytes;
+	u32 rx_errors;
+	u32 tx_errors;
+	u32 rx_dropped;
+	u32 tx_dropped;
+	u32 multicast;
+	u32 collisions;
+	u32 rx_crc_errors;
+	u32 rx_frame_errors;
+	u32 rx_alloc_buff_failed;
+	u32 tx_length_errors;
+	u32 tx_aborted_errors;
+	u32 tx_carrier_errors;
+	u32 tx_timeout_count;
+	u32 tx_restart_count;
+	u32 intr_rx_dsc_empty_count;
+	u32 intr_rx_frame_err_count;
+	u32 intr_rx_fifo_err_count;
+	u32 intr_rx_dma_err_count;
+	u32 intr_tx_fifo_err_count;
+	u32 intr_tx_dma_err_count;
+	u32 intr_tcpip_err_count;
+};
+
+/**
+ * struct pch_gbe_adapter - board specific private data structure
+ * @stats_lock:	Spinlock structure for status
+ * @tx_queue_lock:	Spinlock structure for transmit
+ * @ethtool_lock:	Spinlock structure for ethtool
+ * @irq_sem:		Semaphore for interrupt
+ * @netdev:		Pointer of network device structure
+ * @pdev:		Pointer of pci device structure
+ * @polling_netdev:	Pointer of polling network device structure
+ * @napi:		NAPI structure
+ * @hw:			Pointer of hardware structure
+ * @stats:		Hardware status
+ * @reset_task:		Reset task
+ * @mii:		MII information structure
+ * @watchdog_timer:	Watchdog timer list
+ * @wake_up_evt:	Wake up event
+ * @config_space:	Configuration space
+ * @msg_enable:		Driver message level
+ * @led_status:		LED status
+ * @tx_ring:		Pointer of Tx descriptor ring structure
+ * @rx_ring:		Pointer of Rx descriptor ring structure
+ * @rx_buffer_len:	Receive buffer length
+ * @tx_queue_len:	Transmit queue length
+ * @rx_csum:		Receive TCP/IP checksum enable/disable
+ * @tx_csum:		Transmit TCP/IP checksum enable/disable
+ * @have_msi:		PCI MSI mode flag
+ */
+
+struct pch_gbe_adapter {
+	spinlock_t stats_lock;
+	spinlock_t tx_queue_lock;
+	spinlock_t ethtool_lock;
+	atomic_t irq_sem;
+	struct net_device *netdev;
+	struct pci_dev *pdev;
+	struct net_device *polling_netdev;
+	struct napi_struct napi;
+	struct pch_gbe_hw hw;
+	struct pch_gbe_hw_stats stats;
+	struct work_struct reset_task;
+	struct mii_if_info mii;
+	struct timer_list watchdog_timer;
+	u32 wake_up_evt;
+	u32 *config_space;
+	unsigned long led_status;
+	struct pch_gbe_tx_ring *tx_ring;
+	struct pch_gbe_rx_ring *rx_ring;
+	unsigned long rx_buffer_len;
+	unsigned long tx_queue_len;
+	bool rx_csum;
+	bool tx_csum;
+	bool have_msi;
+};
+
+extern const char pch_driver_version[];
+
+/* pch_gbe_main.c */
+extern int pch_gbe_up(struct pch_gbe_adapter *adapter);
+extern void pch_gbe_down(struct pch_gbe_adapter *adapter);
+extern void pch_gbe_reinit_locked(struct pch_gbe_adapter *adapter);
+extern void pch_gbe_reset(struct pch_gbe_adapter *adapter);
+extern int pch_gbe_setup_tx_resources(struct pch_gbe_adapter *adapter,
+				       struct pch_gbe_tx_ring *txdr);
+extern int pch_gbe_setup_rx_resources(struct pch_gbe_adapter *adapter,
+				       struct pch_gbe_rx_ring *rxdr);
+extern void pch_gbe_free_tx_resources(struct pch_gbe_adapter *adapter,
+				       struct pch_gbe_tx_ring *tx_ring);
+extern void pch_gbe_free_rx_resources(struct pch_gbe_adapter *adapter,
+				       struct pch_gbe_rx_ring *rx_ring);
+extern void pch_gbe_update_stats(struct pch_gbe_adapter *adapter);
+
+/* pch_gbe_param.c */
+extern void pch_gbe_check_options(struct pch_gbe_adapter *adapter);
+
+/* pch_gbe_ethtool.c */
+extern void pch_gbe_set_ethtool_ops(struct net_device *netdev);
+
+/* pch_gbe_mac.c */
+extern s32 pch_gbe_mac_force_mac_fc(struct pch_gbe_hw *hw);
+extern s32 pch_gbe_mac_read_mac_addr(struct pch_gbe_hw *hw);
+extern u16 pch_gbe_mac_ctrl_miim(struct pch_gbe_hw *hw,
+				  u32 addr, u32 dir, u32 reg, u16 data);
+#endif /* _PCH_GBE_H_ */

--- a/pch_gbe/pch_gbe_api.c
+++ b/pch_gbe/pch_gbe_api.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+#include "pch_gbe.h"
+#include "pch_gbe_phy.h"
+
+/* bus type values */
+#define pch_gbe_bus_type_unknown	0
+#define pch_gbe_bus_type_pci		1
+#define pch_gbe_bus_type_pcix		2
+#define pch_gbe_bus_type_pci_express	3
+#define pch_gbe_bus_type_reserved	4
+
+/* bus speed values */
+#define pch_gbe_bus_speed_unknown	0
+#define pch_gbe_bus_speed_33		1
+#define pch_gbe_bus_speed_66		2
+#define pch_gbe_bus_speed_100		3
+#define pch_gbe_bus_speed_120		4
+#define pch_gbe_bus_speed_133		5
+#define pch_gbe_bus_speed_2500		6
+#define pch_gbe_bus_speed_reserved	7
+
+/* bus width values */
+#define pch_gbe_bus_width_unknown	0
+#define pch_gbe_bus_width_pcie_x1	1
+#define pch_gbe_bus_width_pcie_x2	2
+#define pch_gbe_bus_width_pcie_x4	4
+#define pch_gbe_bus_width_32		5
+#define pch_gbe_bus_width_64		6
+#define pch_gbe_bus_width_reserved	7
+
+/**
+ * pch_gbe_plat_get_bus_info - Obtain bus information for adapter
+ * @hw:	Pointer to the HW structure
+ */
+static void pch_gbe_plat_get_bus_info(struct pch_gbe_hw *hw)
+{
+	hw->bus.type  = pch_gbe_bus_type_pci_express;
+	hw->bus.speed = pch_gbe_bus_speed_2500;
+	hw->bus.width = pch_gbe_bus_width_pcie_x1;
+}
+
+/**
+ * pch_gbe_plat_init_hw - Initialize hardware
+ * @hw:	Pointer to the HW structure
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed-EBUSY
+ */
+static s32 pch_gbe_plat_init_hw(struct pch_gbe_hw *hw)
+{
+	s32 ret_val;
+
+	ret_val = pch_gbe_phy_get_id(hw);
+	if (ret_val) {
+		pr_err("pch_gbe_phy_get_id error\n");
+		return ret_val;
+	}
+	pch_gbe_phy_init_setting(hw);
+	/* Setup Mac interface option RGMII */
+#ifdef PCH_GBE_MAC_IFOP_RGMII
+	pch_gbe_phy_set_rgmii(hw);
+#endif
+	return ret_val;
+}
+
+static const struct pch_gbe_functions pch_gbe_ops = {
+	.get_bus_info      = pch_gbe_plat_get_bus_info,
+	.init_hw           = pch_gbe_plat_init_hw,
+	.read_phy_reg      = pch_gbe_phy_read_reg_miic,
+	.write_phy_reg     = pch_gbe_phy_write_reg_miic,
+	.reset_phy         = pch_gbe_phy_hw_reset,
+	.sw_reset_phy      = pch_gbe_phy_sw_reset,
+	.power_up_phy      = pch_gbe_phy_power_up,
+	.power_down_phy    = pch_gbe_phy_power_down,
+	.read_mac_addr     = pch_gbe_mac_read_mac_addr
+};
+
+/**
+ * pch_gbe_plat_init_function_pointers - Init func ptrs
+ * @hw:	Pointer to the HW structure
+ */
+static void pch_gbe_plat_init_function_pointers(struct pch_gbe_hw *hw)
+{
+	/* Set PHY parameter */
+	hw->phy.reset_delay_us     = PCH_GBE_PHY_RESET_DELAY_US;
+	/* Set function pointers */
+	hw->func = &pch_gbe_ops;
+}
+
+/**
+ * pch_gbe_hal_setup_init_funcs - Initializes function pointers
+ * @hw:	Pointer to the HW structure
+ * Returns
+ *	0:	Successfully
+ *	ENOSYS:	Function is not registered
+ */
+inline s32 pch_gbe_hal_setup_init_funcs(struct pch_gbe_hw *hw)
+{
+	if (!hw->reg) {
+		pr_err("ERROR: Registers not mapped\n");
+		return -ENOSYS;
+	}
+	pch_gbe_plat_init_function_pointers(hw);
+	return 0;
+}
+
+/**
+ * pch_gbe_hal_get_bus_info - Obtain bus information for adapter
+ * @hw:	Pointer to the HW structure
+ */
+inline void pch_gbe_hal_get_bus_info(struct pch_gbe_hw *hw)
+{
+	if (!hw->func->get_bus_info)
+		pr_err("ERROR: configuration\n");
+	else
+		hw->func->get_bus_info(hw);
+}
+
+/**
+ * pch_gbe_hal_init_hw - Initialize hardware
+ * @hw:	Pointer to the HW structure
+ * Returns
+ *	0:	Successfully
+ *	ENOSYS:	Function is not registered
+ */
+inline s32 pch_gbe_hal_init_hw(struct pch_gbe_hw *hw)
+{
+	if (!hw->func->init_hw) {
+		pr_err("ERROR: configuration\n");
+		return -ENOSYS;
+	}
+	return hw->func->init_hw(hw);
+}
+
+/**
+ * pch_gbe_hal_read_phy_reg - Reads PHY register
+ * @hw:	    Pointer to the HW structure
+ * @offset: The register to read
+ * @data:   The buffer to store the 16-bit read.
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+inline s32 pch_gbe_hal_read_phy_reg(struct pch_gbe_hw *hw, u32 offset,
+					u16 *data)
+{
+	if (!hw->func->read_phy_reg)
+		return 0;
+	return hw->func->read_phy_reg(hw, offset, data);
+}
+
+/**
+ * pch_gbe_hal_write_phy_reg - Writes PHY register
+ * @hw:	    Pointer to the HW structure
+ * @offset: The register to read
+ * @data:   The value to write.
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+inline s32 pch_gbe_hal_write_phy_reg(struct pch_gbe_hw *hw, u32 offset,
+					u16 data)
+{
+	if (!hw->func->write_phy_reg)
+		return 0;
+	return hw->func->write_phy_reg(hw, offset, data);
+}
+
+/**
+ * pch_gbe_hal_phy_hw_reset - Hard PHY reset
+ * @hw:	    Pointer to the HW structure
+ */
+inline void pch_gbe_hal_phy_hw_reset(struct pch_gbe_hw *hw)
+{
+	if (!hw->func->reset_phy)
+		pr_err("ERROR: configuration\n");
+	else
+		hw->func->reset_phy(hw);
+}
+
+/**
+ * pch_gbe_hal_phy_sw_reset - Soft PHY reset
+ * @hw:	    Pointer to the HW structure
+ */
+inline void pch_gbe_hal_phy_sw_reset(struct pch_gbe_hw *hw)
+{
+	if (!hw->func->sw_reset_phy)
+		pr_err("ERROR: configuration\n");
+	else
+		hw->func->sw_reset_phy(hw);
+}
+
+/**
+ * pch_gbe_hal_read_mac_addr - Reads MAC address
+ * @hw:	Pointer to the HW structure
+ * Returns
+ *	0:	Successfully
+ *	ENOSYS:	Function is not registered
+ */
+inline s32 pch_gbe_hal_read_mac_addr(struct pch_gbe_hw *hw)
+{
+	if (!hw->func->read_mac_addr) {
+		pr_err("ERROR: configuration\n");
+		return -ENOSYS;
+	}
+	return hw->func->read_mac_addr(hw);
+}
+
+/**
+ * pch_gbe_hal_power_up_phy - Power up PHY
+ * @hw:	Pointer to the HW structure
+ */
+inline void pch_gbe_hal_power_up_phy(struct pch_gbe_hw *hw)
+{
+	if (hw->func->power_up_phy)
+		hw->func->power_up_phy(hw);
+}
+
+/**
+ * pch_gbe_hal_power_down_phy - Power down PHY
+ * @hw:	Pointer to the HW structure
+ */
+inline void pch_gbe_hal_power_down_phy(struct pch_gbe_hw *hw)
+{
+	if (hw->func->power_down_phy)
+		hw->func->power_down_phy(hw);
+}

--- a/pch_gbe/pch_gbe_api.h
+++ b/pch_gbe/pch_gbe_api.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+#ifndef _PCH_GBE_API_H_
+#define _PCH_GBE_API_H_
+
+#include "pch_gbe_phy.h"
+
+s32 pch_gbe_hal_setup_init_funcs(struct pch_gbe_hw *hw);
+void pch_gbe_hal_get_bus_info(struct pch_gbe_hw *hw);
+s32 pch_gbe_hal_init_hw(struct pch_gbe_hw *hw);
+s32 pch_gbe_hal_read_phy_reg(struct pch_gbe_hw *hw, u32 offset, u16 *data);
+s32 pch_gbe_hal_write_phy_reg(struct pch_gbe_hw *hw, u32 offset, u16 data);
+void pch_gbe_hal_phy_hw_reset(struct pch_gbe_hw *hw);
+void pch_gbe_hal_phy_sw_reset(struct pch_gbe_hw *hw);
+s32 pch_gbe_hal_read_mac_addr(struct pch_gbe_hw *hw);
+void pch_gbe_hal_power_up_phy(struct pch_gbe_hw *hw);
+void pch_gbe_hal_power_down_phy(struct pch_gbe_hw *hw);
+
+#endif

--- a/pch_gbe/pch_gbe_ethtool.c
+++ b/pch_gbe/pch_gbe_ethtool.c
@@ -1,0 +1,583 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+#include "pch_gbe.h"
+#include "pch_gbe_api.h"
+
+/* WN mod start */
+#define USHRT_MAX       ((u16)(~0U))
+#define SHRT_MAX        ((s16)(USHRT_MAX>>1))
+int ethtool_op_set_tx_ipv6_csum(struct net_device *dev, u32 data)
+{
+	if (data)
+		dev->features |= NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM;
+	else
+		dev->features &= ~(NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
+
+	return 0;
+}
+/* WN mod end */
+
+
+/**
+ * pch_gbe_stats - Stats item infomation
+ */
+struct pch_gbe_stats {
+	char string[ETH_GSTRING_LEN];
+	size_t size;
+	size_t offset;
+};
+
+#define PCH_GBE_STAT(m)						\
+{								\
+	.string = #m,						\
+	.size = FIELD_SIZEOF(struct pch_gbe_hw_stats, m),	\
+	.offset = offsetof(struct pch_gbe_hw_stats, m),		\
+}
+
+/**
+ * pch_gbe_gstrings_stats - ethtool information status name list
+ */
+static const struct pch_gbe_stats pch_gbe_gstrings_stats[] = {
+	PCH_GBE_STAT(rx_packets),
+	PCH_GBE_STAT(tx_packets),
+	PCH_GBE_STAT(rx_bytes),
+	PCH_GBE_STAT(tx_bytes),
+	PCH_GBE_STAT(rx_errors),
+	PCH_GBE_STAT(tx_errors),
+	PCH_GBE_STAT(rx_dropped),
+	PCH_GBE_STAT(tx_dropped),
+	PCH_GBE_STAT(multicast),
+	PCH_GBE_STAT(collisions),
+	PCH_GBE_STAT(rx_crc_errors),
+	PCH_GBE_STAT(rx_frame_errors),
+	PCH_GBE_STAT(rx_alloc_buff_failed),
+	PCH_GBE_STAT(tx_length_errors),
+	PCH_GBE_STAT(tx_aborted_errors),
+	PCH_GBE_STAT(tx_carrier_errors),
+	PCH_GBE_STAT(tx_timeout_count),
+	PCH_GBE_STAT(tx_restart_count),
+	PCH_GBE_STAT(intr_rx_dsc_empty_count),
+	PCH_GBE_STAT(intr_rx_frame_err_count),
+	PCH_GBE_STAT(intr_rx_fifo_err_count),
+	PCH_GBE_STAT(intr_rx_dma_err_count),
+	PCH_GBE_STAT(intr_tx_fifo_err_count),
+	PCH_GBE_STAT(intr_tx_dma_err_count),
+	PCH_GBE_STAT(intr_tcpip_err_count)
+};
+
+#define PCH_GBE_QUEUE_STATS_LEN 0
+#define PCH_GBE_GLOBAL_STATS_LEN	ARRAY_SIZE(pch_gbe_gstrings_stats)
+#define PCH_GBE_STATS_LEN (PCH_GBE_GLOBAL_STATS_LEN + PCH_GBE_QUEUE_STATS_LEN)
+
+#define PCH_GBE_MAC_REGS_LEN    (sizeof(struct pch_gbe_regs) / 4)
+#define PCH_GBE_REGS_LEN        (PCH_GBE_MAC_REGS_LEN + PCH_GBE_PHY_REGS_LEN)
+/**
+ * pch_gbe_get_settings - Get device-specific settings
+ * @netdev: Network interface device structure
+ * @ecmd:   Ethtool command
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_get_settings(struct net_device *netdev,
+				 struct ethtool_cmd *ecmd)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	int ret;
+
+	ret = mii_ethtool_gset(&adapter->mii, ecmd);
+	ecmd->supported &= ~(SUPPORTED_TP | SUPPORTED_1000baseT_Half);
+	ecmd->advertising &= ~(ADVERTISED_TP | ADVERTISED_1000baseT_Half);
+
+	if (!netif_carrier_ok(adapter->netdev))
+		ecmd->speed = -1;
+	return ret;
+}
+
+/**
+ * pch_gbe_set_settings - Set device-specific settings
+ * @netdev: Network interface device structure
+ * @ecmd:   Ethtool command
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_settings(struct net_device *netdev,
+				 struct ethtool_cmd *ecmd)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	int ret;
+
+	pch_gbe_hal_write_phy_reg(hw, MII_BMCR, BMCR_RESET);
+
+	if (ecmd->speed == USHRT_MAX) {
+		ecmd->speed = SPEED_1000;
+		ecmd->duplex = DUPLEX_FULL;
+	}
+	ret = mii_ethtool_sset(&adapter->mii, ecmd);
+	if (ret) {
+		pr_err("Error: mii_ethtool_sset\n");
+		return ret;
+	}
+	hw->mac.link_speed = ecmd->speed;
+	hw->mac.link_duplex = ecmd->duplex;
+	hw->phy.autoneg_advertised = ecmd->advertising;
+	hw->mac.autoneg = ecmd->autoneg;
+	pch_gbe_hal_phy_sw_reset(hw);
+
+	/* reset the link */
+	if (netif_running(adapter->netdev)) {
+		pch_gbe_down(adapter);
+		ret = pch_gbe_up(adapter);
+	} else {
+		pch_gbe_reset(adapter);
+	}
+	return ret;
+}
+
+/**
+ * pch_gbe_get_regs_len - Report the size of device registers
+ * @netdev: Network interface device structure
+ * Returns: the size of device registers.
+ */
+static int pch_gbe_get_regs_len(struct net_device *netdev)
+{
+	return PCH_GBE_REGS_LEN * (int)sizeof(u32);
+}
+
+/**
+ * pch_gbe_get_drvinfo - Report driver information
+ * @netdev:  Network interface device structure
+ * @drvinfo: Driver information structure
+ */
+static void pch_gbe_get_drvinfo(struct net_device *netdev,
+				 struct ethtool_drvinfo *drvinfo)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	strcpy(drvinfo->driver, KBUILD_MODNAME);
+	strcpy(drvinfo->version, pch_driver_version);
+	strcpy(drvinfo->fw_version, "N/A");
+	strcpy(drvinfo->bus_info, pci_name(adapter->pdev));
+	drvinfo->regdump_len = pch_gbe_get_regs_len(netdev);
+}
+
+/**
+ * pch_gbe_get_regs - Get device registers
+ * @netdev: Network interface device structure
+ * @regs:   Ethtool register structure
+ * @p:      Buffer pointer of read device register date
+ */
+static void pch_gbe_get_regs(struct net_device *netdev,
+				struct ethtool_regs *regs, void *p)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct pci_dev *pdev = adapter->pdev;
+	u32 *regs_buff = p;
+	u16 i, tmp;
+
+	regs->version = 0x1000000 | (__u32)pdev->revision << 16 | pdev->device;
+	for (i = 0; i < PCH_GBE_MAC_REGS_LEN; i++)
+		*regs_buff++ = ioread32(&hw->reg->INT_ST + i);
+	/* PHY register */
+	for (i = 0; i < PCH_GBE_PHY_REGS_LEN; i++) {
+		pch_gbe_hal_read_phy_reg(&adapter->hw, i, &tmp);
+		*regs_buff++ = tmp;
+	}
+}
+
+/**
+ * pch_gbe_get_wol - Report whether Wake-on-Lan is enabled
+ * @netdev: Network interface device structure
+ * @wol:    Wake-on-Lan information
+ */
+static void pch_gbe_get_wol(struct net_device *netdev,
+				struct ethtool_wolinfo *wol)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	wol->supported = WAKE_UCAST | WAKE_MCAST | WAKE_BCAST | WAKE_MAGIC;
+	wol->wolopts = 0;
+
+	if ((adapter->wake_up_evt & PCH_GBE_WLC_IND))
+		wol->wolopts |= WAKE_UCAST;
+	if ((adapter->wake_up_evt & PCH_GBE_WLC_MLT))
+		wol->wolopts |= WAKE_MCAST;
+	if ((adapter->wake_up_evt & PCH_GBE_WLC_BR))
+		wol->wolopts |= WAKE_BCAST;
+	if ((adapter->wake_up_evt & PCH_GBE_WLC_MP))
+		wol->wolopts |= WAKE_MAGIC;
+}
+
+/**
+ * pch_gbe_set_wol - Turn Wake-on-Lan on or off
+ * @netdev: Network interface device structure
+ * @wol:    Pointer of wake-on-Lan information straucture
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_wol(struct net_device *netdev,
+				struct ethtool_wolinfo *wol)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	if ((wol->wolopts & (WAKE_PHY | WAKE_ARP | WAKE_MAGICSECURE)))
+		return -EOPNOTSUPP;
+	/* these settings will always override what we currently have */
+	adapter->wake_up_evt = 0;
+
+	if ((wol->wolopts & WAKE_UCAST))
+		adapter->wake_up_evt |= PCH_GBE_WLC_IND;
+	if ((wol->wolopts & WAKE_MCAST))
+		adapter->wake_up_evt |= PCH_GBE_WLC_MLT;
+	if ((wol->wolopts & WAKE_BCAST))
+		adapter->wake_up_evt |= PCH_GBE_WLC_BR;
+	if ((wol->wolopts & WAKE_MAGIC))
+		adapter->wake_up_evt |= PCH_GBE_WLC_MP;
+	return 0;
+}
+
+/**
+ * pch_gbe_nway_reset - Restart autonegotiation
+ * @netdev: Network interface device structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_nway_reset(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	return mii_nway_restart(&adapter->mii);
+}
+
+/**
+ * pch_gbe_get_ringparam - Report ring sizes
+ * @netdev:  Network interface device structure
+ * @ring:    Ring param structure
+ */
+static void pch_gbe_get_ringparam(struct net_device *netdev,
+					struct ethtool_ringparam *ring)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_tx_ring *txdr = adapter->tx_ring;
+	struct pch_gbe_rx_ring *rxdr = adapter->rx_ring;
+
+	ring->rx_max_pending = PCH_GBE_MAX_RXD;
+	ring->tx_max_pending = PCH_GBE_MAX_TXD;
+	ring->rx_mini_max_pending = 0;
+	ring->rx_jumbo_max_pending = 0;
+	ring->rx_pending = rxdr->count;
+	ring->tx_pending = txdr->count;
+	ring->rx_mini_pending = 0;
+	ring->rx_jumbo_pending = 0;
+}
+
+/**
+ * pch_gbe_set_ringparam - Set ring sizes
+ * @netdev:  Network interface device structure
+ * @ring:    Ring param structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_ringparam(struct net_device *netdev,
+					struct ethtool_ringparam *ring)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_tx_ring *txdr, *tx_old;
+	struct pch_gbe_rx_ring *rxdr, *rx_old;
+	int tx_ring_size, rx_ring_size;
+	int err = 0;
+
+	if ((ring->rx_mini_pending) || (ring->rx_jumbo_pending))
+		return -EINVAL;
+	tx_ring_size = (int)sizeof(struct pch_gbe_tx_ring);
+	rx_ring_size = (int)sizeof(struct pch_gbe_rx_ring);
+
+	if ((netif_running(adapter->netdev)))
+		pch_gbe_down(adapter);
+	tx_old = adapter->tx_ring;
+	rx_old = adapter->rx_ring;
+
+	txdr = kzalloc(tx_ring_size, GFP_KERNEL);
+	if (!txdr) {
+		err = -ENOMEM;
+		goto err_alloc_tx;
+	}
+	rxdr = kzalloc(rx_ring_size, GFP_KERNEL);
+	if (!rxdr) {
+		err = -ENOMEM;
+		goto err_alloc_rx;
+	}
+	adapter->tx_ring = txdr;
+	adapter->rx_ring = rxdr;
+
+	rxdr->count =
+		clamp_val(ring->rx_pending, PCH_GBE_MIN_RXD, PCH_GBE_MAX_RXD);
+	rxdr->count = roundup(rxdr->count, PCH_GBE_RX_DESC_MULTIPLE);
+
+	txdr->count =
+		clamp_val(ring->tx_pending, PCH_GBE_MIN_RXD, PCH_GBE_MAX_RXD);
+	txdr->count = roundup(txdr->count, PCH_GBE_TX_DESC_MULTIPLE);
+
+	if ((netif_running(adapter->netdev))) {
+		/* Try to get new resources before deleting old */
+		err = pch_gbe_setup_rx_resources(adapter, adapter->rx_ring);
+		if (err)
+			goto err_setup_rx;
+		err = pch_gbe_setup_tx_resources(adapter, adapter->tx_ring);
+		if (err)
+			goto err_setup_tx;
+		/* save the new, restore the old in order to free it,
+		 * then restore the new back again */
+#ifdef RINGFREE
+		adapter->rx_ring = rx_old;
+		adapter->tx_ring = tx_old;
+		pch_gbe_free_rx_resources(adapter, adapter->rx_ring);
+		pch_gbe_free_tx_resources(adapter, adapter->tx_ring);
+		kfree(tx_old);
+		kfree(rx_old);
+		adapter->rx_ring = rxdr;
+		adapter->tx_ring = txdr;
+#else
+		pch_gbe_free_rx_resources(adapter, rx_old);
+		pch_gbe_free_tx_resources(adapter, tx_old);
+		kfree(tx_old);
+		kfree(rx_old);
+		adapter->rx_ring = rxdr;
+		adapter->tx_ring = txdr;
+#endif
+		err = pch_gbe_up(adapter);
+	}
+	return err;
+
+err_setup_tx:
+	pch_gbe_free_rx_resources(adapter, adapter->rx_ring);
+err_setup_rx:
+	adapter->rx_ring = rx_old;
+	adapter->tx_ring = tx_old;
+	kfree(rxdr);
+err_alloc_rx:
+	kfree(txdr);
+err_alloc_tx:
+	if (netif_running(adapter->netdev))
+		pch_gbe_up(adapter);
+	return err;
+}
+
+/**
+ * pch_gbe_get_pauseparam - Report pause parameters
+ * @netdev:  Network interface device structure
+ * @pause:   Pause parameters structure
+ */
+static void pch_gbe_get_pauseparam(struct net_device *netdev,
+				       struct ethtool_pauseparam *pause)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	pause->autoneg =
+	    ((hw->mac.fc_autoneg) ? AUTONEG_ENABLE : AUTONEG_DISABLE);
+
+	if (hw->mac.fc == PCH_GBE_FC_RX_PAUSE) {
+		pause->rx_pause = 1;
+	} else if (hw->mac.fc == PCH_GBE_FC_TX_PAUSE) {
+		pause->tx_pause = 1;
+	} else if (hw->mac.fc == PCH_GBE_FC_FULL) {
+		pause->rx_pause = 1;
+		pause->tx_pause = 1;
+	}
+}
+
+/**
+ * pch_gbe_set_pauseparam - Set pause paramters
+ * @netdev:  Network interface device structure
+ * @pause:   Pause parameters structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_pauseparam(struct net_device *netdev,
+				       struct ethtool_pauseparam *pause)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	int ret = 0;
+
+	hw->mac.fc_autoneg = pause->autoneg;
+	if ((pause->rx_pause) && (pause->tx_pause))
+		hw->mac.fc = PCH_GBE_FC_FULL;
+	else if ((pause->rx_pause) && (!pause->tx_pause))
+		hw->mac.fc = PCH_GBE_FC_RX_PAUSE;
+	else if ((!pause->rx_pause) && (pause->tx_pause))
+		hw->mac.fc = PCH_GBE_FC_TX_PAUSE;
+	else if ((!pause->rx_pause) && (!pause->tx_pause))
+		hw->mac.fc = PCH_GBE_FC_NONE;
+
+	if (hw->mac.fc_autoneg == AUTONEG_ENABLE) {
+		if ((netif_running(adapter->netdev))) {
+			pch_gbe_down(adapter);
+			ret = pch_gbe_up(adapter);
+		} else {
+			pch_gbe_reset(adapter);
+		}
+	} else {
+		ret = pch_gbe_mac_force_mac_fc(hw);
+	}
+	return ret;
+}
+
+/**
+ * pch_gbe_get_rx_csum - Report whether receive checksums are turned on or off
+ * @netdev:  Network interface device structure
+ * Returns
+ *	true(1):  Checksum On
+ *	false(0): Checksum Off
+ */
+static u32 pch_gbe_get_rx_csum(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	return adapter->rx_csum;
+}
+
+/**
+ * pch_gbe_set_rx_csum - Turn receive checksum on or off
+ * @netdev:  Network interface device structure
+ * @data:    Checksum On[true] or Off[false]
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_rx_csum(struct net_device *netdev, u32 data)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	adapter->rx_csum = data;
+	if ((netif_running(netdev)))
+		pch_gbe_reinit_locked(adapter);
+	else
+		pch_gbe_reset(adapter);
+
+	return 0;
+}
+
+/**
+ * pch_gbe_set_tx_csum - Turn transmit checksums on or off
+ * @netdev: Network interface device structure
+ * @data:   Checksum on[true] or off[false]
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_set_tx_csum(struct net_device *netdev, u32 data)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	adapter->tx_csum = data;
+	return ethtool_op_set_tx_ipv6_csum(netdev, data);
+}
+
+/**
+ * pch_gbe_get_strings - Return a set of strings that describe the requested
+ *			 objects
+ * @netdev:    Network interface device structure
+ * @stringset: Select the stringset. [ETH_SS_TEST] [ETH_SS_STATS]
+ * @data:      Pointer of read string data.
+ */
+static void pch_gbe_get_strings(struct net_device *netdev, u32 stringset,
+					u8 *data)
+{
+	u8 *p = data;
+	int i;
+
+	switch (stringset) {
+	case (u32) ETH_SS_STATS:
+		for (i = 0; i < PCH_GBE_GLOBAL_STATS_LEN; i++) {
+			memcpy(p, pch_gbe_gstrings_stats[i].string,
+			       ETH_GSTRING_LEN);
+			p += ETH_GSTRING_LEN;
+		}
+		break;
+	}
+}
+
+/**
+ * pch_gbe_get_ethtool_stats - Return statistics about the device
+ * @netdev: Network interface device structure
+ * @stats:  Ethtool statue structure
+ * @data:   Pointer of read status area
+ */
+static void pch_gbe_get_ethtool_stats(struct net_device *netdev,
+				  struct ethtool_stats *stats, u64 *data)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	int i;
+	const struct pch_gbe_stats *gstats = pch_gbe_gstrings_stats;
+	char *hw_stats = (char *)&adapter->stats;
+
+	pch_gbe_update_stats(adapter);
+	for (i = 0; i < PCH_GBE_GLOBAL_STATS_LEN; i++) {
+		char *p = hw_stats + gstats->offset;
+		data[i] = gstats->size == sizeof(u64) ? *(u64 *)p:(*(u32 *)p);
+		gstats++;
+	}
+}
+
+static int pch_gbe_get_sset_count(struct net_device *netdev, int sset)
+{
+	switch (sset) {
+	case ETH_SS_STATS:
+		return PCH_GBE_STATS_LEN;
+	default:
+		return -EOPNOTSUPP;
+	}
+}
+
+static const struct ethtool_ops pch_gbe_ethtool_ops = {
+	.get_settings = pch_gbe_get_settings,
+	.set_settings = pch_gbe_set_settings,
+	.get_drvinfo = pch_gbe_get_drvinfo,
+	.get_regs_len = pch_gbe_get_regs_len,
+	.get_regs = pch_gbe_get_regs,
+	.get_wol = pch_gbe_get_wol,
+	.set_wol = pch_gbe_set_wol,
+	.nway_reset = pch_gbe_nway_reset,
+	.get_link = ethtool_op_get_link,
+	.get_ringparam = pch_gbe_get_ringparam,
+	.set_ringparam = pch_gbe_set_ringparam,
+	.get_pauseparam = pch_gbe_get_pauseparam,
+	.set_pauseparam = pch_gbe_set_pauseparam,
+	.get_rx_csum = pch_gbe_get_rx_csum,
+	.set_rx_csum = pch_gbe_set_rx_csum,
+	.set_tx_csum = pch_gbe_set_tx_csum,
+	.get_strings = pch_gbe_get_strings,
+	.get_ethtool_stats = pch_gbe_get_ethtool_stats,
+	.get_sset_count = pch_gbe_get_sset_count,
+};
+
+void pch_gbe_set_ethtool_ops(struct net_device *netdev)
+{
+	SET_ETHTOOL_OPS(netdev, &pch_gbe_ethtool_ops);
+}

--- a/pch_gbe/pch_gbe_main.c
+++ b/pch_gbe/pch_gbe_main.c
@@ -1,0 +1,2517 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR CO., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+//#define vzalloc vmalloc
+#include "pch_gbe.h"
+#include "pch_gbe_api.h"
+void* vzalloc (int s)
+{
+	void * buff=vmalloc(s);
+	memset(buff,0,s);
+	return buff;
+}
+
+#define DRV_VERSION     "1.00"
+const char pch_driver_version[] = DRV_VERSION;
+
+#define PCI_DEVICE_ID_INTEL_IOH1_GBE	0x8802		/* Pci device ID */
+#define PCH_GBE_MAR_ENTRIES		16
+#define PCH_GBE_SHORT_PKT		64
+#define DSC_INIT16			0xC000
+#define PCH_GBE_DMA_ALIGN		0
+#define PCH_GBE_DMA_PADDING		2
+#define PCH_GBE_WATCHDOG_PERIOD		(1 * HZ)	/* watchdog time */
+#define PCH_GBE_COPYBREAK_DEFAULT	256
+#define PCH_GBE_PCI_BAR			1
+
+#define PCH_GBE_TX_WEIGHT         64
+#define PCH_GBE_RX_WEIGHT         64
+#define PCH_GBE_RX_BUFFER_WRITE   16
+
+/* Initialize the wake-on-LAN settings */
+#define PCH_GBE_WL_INIT_SETTING    (PCH_GBE_WLC_MP)
+
+#define PCH_GBE_MAC_RGMII_CTRL_SETTING ( \
+	PCH_GBE_CHIP_TYPE_INTERNAL | \
+	PCH_GBE_RGMII_MODE_RGMII   | \
+	PCH_GBE_CRS_SEL              \
+	)
+
+/* Ethertype field values */
+#define PCH_GBE_MAX_JUMBO_FRAME_SIZE    10318
+#define PCH_GBE_FRAME_SIZE_2048         2048
+#define PCH_GBE_FRAME_SIZE_4096         4096
+#define PCH_GBE_FRAME_SIZE_8192         8192
+
+#define PCH_GBE_GET_DESC(R, i, type)    (&(((struct type *)((R).desc))[i]))
+#define PCH_GBE_RX_DESC(R, i)           PCH_GBE_GET_DESC(R, i, pch_gbe_rx_desc)
+#define PCH_GBE_TX_DESC(R, i)           PCH_GBE_GET_DESC(R, i, pch_gbe_tx_desc)
+#define PCH_GBE_DESC_UNUSED(R) \
+	((((R)->next_to_clean > (R)->next_to_use) ? 0 : (R)->count) + \
+	(R)->next_to_clean - (R)->next_to_use - 1)
+
+/* Pause packet value */
+#define	PCH_GBE_PAUSE_PKT1_VALUE    0x00C28001
+#define	PCH_GBE_PAUSE_PKT2_VALUE    0x00000100
+#define	PCH_GBE_PAUSE_PKT4_VALUE    0x01000888
+#define	PCH_GBE_PAUSE_PKT5_VALUE    0x0000FFFF
+
+#define PCH_GBE_ETH_ALEN            6
+
+/* This defines the bits that are set in the Interrupt Mask
+ * Set/Read Register.  Each bit is documented below:
+ *   o RXT0   = Receiver Timer Interrupt (ring 0)
+ *   o TXDW   = Transmit Descriptor Written Back
+ *   o RXDMT0 = Receive Descriptor Minimum Threshold hit (ring 0)
+ *   o RXSEQ  = Receive Sequence Error
+ *   o LSC    = Link Status Change
+ */
+#define PCH_GBE_INT_ENABLE_MASK ( \
+	PCH_GBE_INT_RX_DMA_CMPLT |    \
+	PCH_GBE_INT_RX_DSC_EMP   |    \
+	PCH_GBE_INT_WOL_DET      |    \
+	PCH_GBE_INT_TX_CMPLT          \
+	)
+
+
+static unsigned int copybreak __read_mostly = PCH_GBE_COPYBREAK_DEFAULT;
+
+static int pch_gbe_mdio_read(struct net_device *netdev, int addr, int reg);
+static void pch_gbe_mdio_write(struct net_device *netdev, int addr, int reg,
+			       int data);
+
+inline void pch_gbe_mac_load_mac_addr(struct pch_gbe_hw *hw)
+{
+	iowrite32(0x01, &hw->reg->MAC_ADDR_LOAD);
+}
+
+/**
+ * pch_gbe_mac_read_mac_addr - Read MAC address
+ * @hw:	            Pointer to the HW structure
+ * Returns
+ *	0:			Successful.
+ */
+s32 pch_gbe_mac_read_mac_addr(struct pch_gbe_hw *hw)
+{
+	u32  adr1a, adr1b;
+
+	adr1a = ioread32(&hw->reg->mac_adr[0].high);
+	adr1b = ioread32(&hw->reg->mac_adr[0].low);
+
+	hw->mac.addr[0] = (u8)(adr1a & 0xFF);
+	hw->mac.addr[1] = (u8)((adr1a >> 8) & 0xFF);
+	hw->mac.addr[2] = (u8)((adr1a >> 16) & 0xFF);
+	hw->mac.addr[3] = (u8)((adr1a >> 24) & 0xFF);
+	hw->mac.addr[4] = (u8)(adr1b & 0xFF);
+	hw->mac.addr[5] = (u8)((adr1b >> 8) & 0xFF);
+
+	pr_debug("hw->mac.addr : %pM\n", hw->mac.addr);
+	return 0;
+}
+
+/**
+ * pch_gbe_wait_clr_bit - Wait to clear a bit
+ * @reg:	Pointer of register
+ * @busy:	Busy bit
+ */
+static void pch_gbe_wait_clr_bit(void *reg, u32 bit)
+{
+	u32 tmp;
+	/* wait busy */
+	tmp = 1000;
+	while ((ioread32(reg) & bit) && --tmp)
+		cpu_relax();
+	if (!tmp)
+		pr_err("Error: busy bit is not cleared\n");
+}
+/**
+ * pch_gbe_mac_mar_set - Set MAC address register
+ * @hw:	    Pointer to the HW structure
+ * @addr:   Pointer to the MAC address
+ * @index:  MAC address array register
+ */
+static void pch_gbe_mac_mar_set(struct pch_gbe_hw *hw, u8 * addr, u32 index)
+{
+	u32 mar_low, mar_high, adrmask;
+
+	pr_debug("index : 0x%x\n", index);
+
+	/*
+	 * HW expects these in little endian so we reverse the byte order
+	 * from network order (big endian) to little endian
+	 */
+	mar_high = ((u32) addr[0] | ((u32) addr[1] << 8) |
+		   ((u32) addr[2] << 16) | ((u32) addr[3] << 24));
+	mar_low = ((u32) addr[4] | ((u32) addr[5] << 8));
+	/* Stop the MAC Address of index. */
+	adrmask = ioread32(&hw->reg->ADDR_MASK);
+	iowrite32((adrmask | (0x0001 << index)), &hw->reg->ADDR_MASK);
+	/* wait busy */
+	pch_gbe_wait_clr_bit(&hw->reg->ADDR_MASK, PCH_GBE_BUSY);
+	/* Set the MAC address to the MAC address 1A/1B register */
+	iowrite32(mar_high, &hw->reg->mac_adr[index].high);
+	iowrite32(mar_low, &hw->reg->mac_adr[index].low);
+	/* Start the MAC address of index */
+	iowrite32((adrmask & ~(0x0001 << index)), &hw->reg->ADDR_MASK);
+	/* wait busy */
+	pch_gbe_wait_clr_bit(&hw->reg->ADDR_MASK, PCH_GBE_BUSY);
+}
+
+/**
+ * pch_gbe_mac_reset_hw - Reset hardware
+ * @hw:	Pointer to the HW structure
+ */
+static void pch_gbe_mac_reset_hw(struct pch_gbe_hw *hw)
+{
+	/* Read the MAC address. and store to the private data */
+	pch_gbe_mac_read_mac_addr(hw);
+	iowrite32(PCH_GBE_ALL_RST, &hw->reg->RESET);
+#ifdef PCH_GBE_MAC_IFOP_RGMII
+	iowrite32(PCH_GBE_MODE_GMII_ETHER, &hw->reg->MODE);
+#endif
+	pch_gbe_wait_clr_bit(&hw->reg->RESET, PCH_GBE_ALL_RST);
+	/* Setup the receive address */
+	pch_gbe_mac_mar_set(hw, hw->mac.addr, 0);
+	return;
+}
+
+/**
+ * pch_gbe_mac_init_rx_addrs - Initialize receive address's
+ * @hw:	Pointer to the HW structure
+ * @mar_count: Receive address registers
+ */
+static void pch_gbe_mac_init_rx_addrs(struct pch_gbe_hw *hw, u16 mar_count)
+{
+	u32 i;
+
+	/* Setup the receive address */
+	pch_gbe_mac_mar_set(hw, hw->mac.addr, 0);
+
+	/* Zero out the other receive addresses */
+	for (i = 1; i < mar_count; i++) {
+		iowrite32(0, &hw->reg->mac_adr[i].high);
+		iowrite32(0, &hw->reg->mac_adr[i].low);
+	}
+	iowrite32(0xFFFE, &hw->reg->ADDR_MASK);
+	/* wait busy */
+	pch_gbe_wait_clr_bit(&hw->reg->ADDR_MASK, PCH_GBE_BUSY);
+}
+
+
+/**
+ * pch_gbe_mac_mc_addr_list_update - Update Multicast addresses
+ * @hw:	            Pointer to the HW structure
+ * @mc_addr_list:   Array of multicast addresses to program
+ * @mc_addr_count:  Number of multicast addresses to program
+ * @mar_used_count: The first MAC Address register free to program
+ * @mar_total_num:  Total number of supported MAC Address Registers
+ */
+static void pch_gbe_mac_mc_addr_list_update(struct pch_gbe_hw *hw,
+					    u8 *mc_addr_list, u32 mc_addr_count,
+					    u32 mar_used_count, u32 mar_total_num)
+{
+	u32 i, adrmask;
+
+	/* Load the first set of multicast addresses into the exact
+	 * filters (RAR).  If there are not enough to fill the RAR
+	 * array, clear the filters.
+	 */
+	for (i = mar_used_count; i < mar_total_num; i++) {
+		if (mc_addr_count) {
+			pch_gbe_mac_mar_set(hw, mc_addr_list, i);
+			mc_addr_count--;
+			mc_addr_list += PCH_GBE_ETH_ALEN;
+		} else {
+			/* Clear MAC address mask */
+			adrmask = ioread32(&hw->reg->ADDR_MASK);
+			iowrite32((adrmask | (0x0001 << i)),
+					&hw->reg->ADDR_MASK);
+			/* wait busy */
+			pch_gbe_wait_clr_bit(&hw->reg->ADDR_MASK, PCH_GBE_BUSY);
+			/* Clear MAC address */
+			iowrite32(0, &hw->reg->mac_adr[i].high);
+			iowrite32(0, &hw->reg->mac_adr[i].low);
+		}
+	}
+}
+
+/**
+ * pch_gbe_mac_force_mac_fc - Force the MAC's flow control settings
+ * @hw:	            Pointer to the HW structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+s32 pch_gbe_mac_force_mac_fc(struct pch_gbe_hw *hw)
+{
+	struct pch_gbe_mac_info *mac = &hw->mac;
+	u32 rx_fctrl;
+
+	pr_debug("mac->fc = %u\n", mac->fc);
+
+	rx_fctrl = ioread32(&hw->reg->RX_FCTRL);
+
+	switch (mac->fc) {
+	case PCH_GBE_FC_NONE:
+		rx_fctrl &= ~PCH_GBE_FL_CTRL_EN;
+		mac->tx_fc_enable = false;
+		break;
+	case PCH_GBE_FC_RX_PAUSE:
+		rx_fctrl |= PCH_GBE_FL_CTRL_EN;
+		mac->tx_fc_enable = false;
+		break;
+	case PCH_GBE_FC_TX_PAUSE:
+		rx_fctrl &= ~PCH_GBE_FL_CTRL_EN;
+		mac->tx_fc_enable = true;
+		break;
+	case PCH_GBE_FC_FULL:
+		rx_fctrl |= PCH_GBE_FL_CTRL_EN;
+		mac->tx_fc_enable = true;
+		break;
+	default:
+		pr_err("Flow control param set incorrectly\n");
+		return -EINVAL;
+	}
+	if (mac->link_duplex == DUPLEX_HALF)
+		rx_fctrl &= ~PCH_GBE_FL_CTRL_EN;
+	iowrite32(rx_fctrl, &hw->reg->RX_FCTRL);
+	pr_debug("RX_FCTRL reg : 0x%08x  mac->tx_fc_enable : %d\n",
+		 ioread32(&hw->reg->RX_FCTRL), mac->tx_fc_enable);
+	return 0;
+}
+
+/**
+ * pch_gbe_mac_set_wol_event - Set wake-on-lan event
+ * @hw:     Pointer to the HW structure
+ * @wu_evt: Wake up event
+ */
+static void pch_gbe_mac_set_wol_event(struct pch_gbe_hw *hw, u32 wu_evt)
+{
+	u32 addr_mask;
+
+	pr_debug("wu_evt : 0x%08x  ADDR_MASK reg : 0x%08x\n",
+		 wu_evt, ioread32(&hw->reg->ADDR_MASK));
+
+	if (wu_evt) {
+		/* Set Wake-On-Lan address mask */
+		addr_mask = ioread32(&hw->reg->ADDR_MASK);
+		iowrite32(addr_mask, &hw->reg->WOL_ADDR_MASK);
+		/* wait busy */
+		pch_gbe_wait_clr_bit(&hw->reg->WOL_ADDR_MASK, PCH_GBE_WLA_BUSY);
+		iowrite32(0, &hw->reg->WOL_ST);
+		iowrite32((wu_evt | PCH_GBE_WLC_WOL_MODE), &hw->reg->WOL_CTRL);
+		iowrite32(0x02, &hw->reg->TCPIP_ACC);
+		iowrite32(PCH_GBE_INT_ENABLE_MASK, &hw->reg->INT_EN);
+	} else {
+		iowrite32(0, &hw->reg->WOL_CTRL);
+		iowrite32(0, &hw->reg->WOL_ST);
+	}
+	return;
+}
+
+/**
+ * pch_gbe_mac_ctrl_miim - Control MIIM interface
+ * @hw:   Pointer to the HW structure
+ * @addr: Address of PHY
+ * @dir:  Operetion. (Write or Read)
+ * @reg:  Access register of PHY
+ * @data: Write data.
+ *
+ * Returns: Read date.
+ */
+u16 pch_gbe_mac_ctrl_miim(struct pch_gbe_hw *hw, u32 addr, u32 dir, u32 reg,
+			u16 data)
+{
+	u32 data_out = 0;
+	unsigned int i;
+	unsigned long flags;
+
+	spin_lock_irqsave(&hw->miim_lock, flags);
+
+	for (i = 100; i; --i) {
+		if ((ioread32(&hw->reg->MIIM) & PCH_GBE_MIIM_OPER_READY))
+			break;
+		udelay(20);
+	}
+	if (i == 0) {
+		pr_err("pch-gbe.miim won't go Ready\n");
+		spin_unlock_irqrestore(&hw->miim_lock, flags);
+		return 0;	/* No way to indicate timeout error */
+	}
+	iowrite32(((reg << PCH_GBE_MIIM_REG_ADDR_SHIFT) |
+		  (addr << PCH_GBE_MIIM_PHY_ADDR_SHIFT) |
+		  dir | data), &hw->reg->MIIM);
+	for (i = 0; i < 100; i++) {
+		udelay(20);
+		data_out = ioread32(&hw->reg->MIIM);
+		if ((data_out & PCH_GBE_MIIM_OPER_READY))
+			break;
+	}
+	spin_unlock_irqrestore(&hw->miim_lock, flags);
+
+	pr_debug("PHY %s: reg=%d, data=0x%04X\n",
+		 dir == PCH_GBE_MIIM_OPER_READ ? "READ" : "WRITE", reg,
+		 dir == PCH_GBE_MIIM_OPER_READ ? data_out : data);
+	return (u16) data_out;
+}
+
+/**
+ * pch_gbe_mac_set_pause_packet - Set pause packet
+ * @hw:   Pointer to the HW structure
+ */
+static void pch_gbe_mac_set_pause_packet(struct pch_gbe_hw *hw)
+{
+	unsigned long tmp2, tmp3;
+
+	/* Set Pause packet */
+	tmp2 = hw->mac.addr[1];
+	tmp2 = (tmp2 << 8) | hw->mac.addr[0];
+	tmp2 = PCH_GBE_PAUSE_PKT2_VALUE | (tmp2 << 16);
+
+	tmp3 = hw->mac.addr[5];
+	tmp3 = (tmp3 << 8) | hw->mac.addr[4];
+	tmp3 = (tmp3 << 8) | hw->mac.addr[3];
+	tmp3 = (tmp3 << 8) | hw->mac.addr[2];
+
+	iowrite32(PCH_GBE_PAUSE_PKT1_VALUE, &hw->reg->PAUSE_PKT1);
+	iowrite32(tmp2, &hw->reg->PAUSE_PKT2);
+	iowrite32(tmp3, &hw->reg->PAUSE_PKT3);
+	iowrite32(PCH_GBE_PAUSE_PKT4_VALUE, &hw->reg->PAUSE_PKT4);
+	iowrite32(PCH_GBE_PAUSE_PKT5_VALUE, &hw->reg->PAUSE_PKT5);
+
+	/* Transmit Pause Packet */
+	iowrite32(PCH_GBE_PS_PKT_RQ, &hw->reg->PAUSE_REQ);
+
+	pr_debug("PAUSE_PKT1-5 reg : 0x%08x 0x%08x 0x%08x 0x%08x 0x%08x\n",
+		 ioread32(&hw->reg->PAUSE_PKT1), ioread32(&hw->reg->PAUSE_PKT2),
+		 ioread32(&hw->reg->PAUSE_PKT3), ioread32(&hw->reg->PAUSE_PKT4),
+		 ioread32(&hw->reg->PAUSE_PKT5));
+
+	return;
+}
+
+
+/**
+ * pch_gbe_alloc_queues - Allocate memory for all rings
+ * @adapter:  Board private structure to initialize
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_alloc_queues(struct pch_gbe_adapter *adapter)
+{
+	int size;
+
+	size = (int)sizeof(struct pch_gbe_tx_ring);
+	adapter->tx_ring = kzalloc(size, GFP_KERNEL);
+	if (!adapter->tx_ring)
+		return -ENOMEM;
+	size = (int)sizeof(struct pch_gbe_rx_ring);
+	adapter->rx_ring = kzalloc(size, GFP_KERNEL);
+	if (!adapter->rx_ring) {
+		kfree(adapter->tx_ring);
+		return -ENOMEM;
+	}
+	return 0;
+}
+
+/**
+ * pch_gbe_init_stats - Initialize status
+ * @adapter:  Board private structure to initialize
+ */
+static void pch_gbe_init_stats(struct pch_gbe_adapter *adapter)
+{
+	memset(&adapter->stats, 0, sizeof(adapter->stats));
+	return;
+}
+
+/**
+ * pch_gbe_init_phy - Initialize PHY
+ * @adapter:  Board private structure to initialize
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_init_phy(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+	u32 addr;
+	u16 bmcr, stat;
+
+	/* Discover phy addr by searching addrs in order {1,0,2,..., 31} */
+	for (addr = 0; addr < PCH_GBE_PHY_REGS_LEN; addr++) {
+		adapter->mii.phy_id = (addr == 0) ? 1 : (addr == 1) ? 0 : addr;
+		bmcr = pch_gbe_mdio_read(netdev, adapter->mii.phy_id, MII_BMCR);
+		stat = pch_gbe_mdio_read(netdev, adapter->mii.phy_id, MII_BMSR);
+		stat = pch_gbe_mdio_read(netdev, adapter->mii.phy_id, MII_BMSR);
+		if (!((bmcr == 0xFFFF) || ((stat == 0) && (bmcr == 0))))
+			break;
+	}
+	adapter->hw.phy.addr = adapter->mii.phy_id;
+	pr_debug("phy_addr = %d\n", adapter->mii.phy_id);
+	if (addr == 32)
+		return -EAGAIN;
+	/* Selected the phy and isolate the rest */
+	for (addr = 0; addr < PCH_GBE_PHY_REGS_LEN; addr++) {
+		if (addr != adapter->mii.phy_id) {
+			pch_gbe_mdio_write(netdev, addr, MII_BMCR,
+					   BMCR_ISOLATE);
+		} else {
+			bmcr = pch_gbe_mdio_read(netdev, addr, MII_BMCR);
+			pch_gbe_mdio_write(netdev, addr, MII_BMCR,
+					   bmcr & ~BMCR_ISOLATE);
+		}
+	}
+
+	/* MII setup */
+	adapter->mii.phy_id_mask = 0x1F;
+	adapter->mii.reg_num_mask = 0x1F;
+	adapter->mii.dev = adapter->netdev;
+	adapter->mii.mdio_read = pch_gbe_mdio_read;
+	adapter->mii.mdio_write = pch_gbe_mdio_write;
+	adapter->mii.supports_gmii = mii_check_gmii_support(&adapter->mii);
+	return 0;
+}
+
+/**
+ * pch_gbe_mdio_read - The read function for mii
+ * @netdev: Network interface device structure
+ * @addr:   Phy ID
+ * @reg:    Access location
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_mdio_read(struct net_device *netdev, int addr, int reg)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	return pch_gbe_mac_ctrl_miim(hw, addr, PCH_GBE_HAL_MIIM_READ, reg,
+				     (u16) 0);
+}
+
+/**
+ * pch_gbe_mdio_write - The write function for mii
+ * @netdev: Network interface device structure
+ * @addr:   Phy ID (not used)
+ * @reg:    Access location
+ * @data:   Write data
+ */
+static void pch_gbe_mdio_write(struct net_device *netdev,
+			       int addr, int reg, int data)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	pch_gbe_mac_ctrl_miim(hw, addr, PCH_GBE_HAL_MIIM_WRITE, reg, data);
+}
+
+/**
+ * pch_gbe_reset_task - Reset processing at the time of transmission timeout
+ * @work:  Pointer of board private structure
+ */
+static void pch_gbe_reset_task(struct work_struct *work)
+{
+	struct pch_gbe_adapter *adapter;
+	adapter = container_of(work, struct pch_gbe_adapter, reset_task);
+
+	rtnl_lock();
+	pch_gbe_reinit_locked(adapter);
+	rtnl_unlock();
+}
+
+/**
+ * pch_gbe_reinit_locked- Re-initialization
+ * @adapter:  Board private structure
+ */
+void pch_gbe_reinit_locked(struct pch_gbe_adapter *adapter)
+{
+	pch_gbe_down(adapter);
+	pch_gbe_up(adapter);
+}
+
+/**
+ * pch_gbe_reset - Reset GbE
+ * @adapter:  Board private structure
+ */
+void pch_gbe_reset(struct pch_gbe_adapter *adapter)
+{
+	pch_gbe_mac_reset_hw(&adapter->hw);
+	/* Setup the receive address. */
+	pch_gbe_mac_init_rx_addrs(&adapter->hw, PCH_GBE_MAR_ENTRIES);
+	if (pch_gbe_hal_init_hw(&adapter->hw))
+		pr_err("Hardware Error\n");
+}
+
+/**
+ * pch_gbe_free_irq - Free an interrupt
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_free_irq(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+
+	free_irq(adapter->pdev->irq, netdev);
+	if (adapter->have_msi) {
+		pci_disable_msi(adapter->pdev);
+		pr_debug("call pci_disable_msi\n");
+	}
+}
+
+/**
+ * pch_gbe_irq_disable - Mask off interrupt generation on the NIC
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_irq_disable(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	atomic_inc(&adapter->irq_sem);
+	iowrite32(0, &hw->reg->INT_EN);
+	ioread32(&hw->reg->INT_ST);
+	synchronize_irq(adapter->pdev->irq);
+
+	pr_debug("INT_EN reg : 0x%08x\n", ioread32(&hw->reg->INT_EN));
+}
+
+/**
+ * pch_gbe_irq_enable - Enable default interrupt generation settings
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_irq_enable(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	if (likely(atomic_dec_and_test(&adapter->irq_sem)))
+		iowrite32(PCH_GBE_INT_ENABLE_MASK, &hw->reg->INT_EN);
+	ioread32(&hw->reg->INT_ST);
+	pr_debug("INT_EN reg : 0x%08x\n", ioread32(&hw->reg->INT_EN));
+}
+
+
+
+/**
+ * pch_gbe_setup_tctl - configure the Transmit control registers
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_setup_tctl(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 tx_mode, tcpip;
+
+	tx_mode = PCH_GBE_TM_LONG_PKT |
+		PCH_GBE_TM_ST_AND_FD |
+		PCH_GBE_TM_SHORT_PKT |
+		PCH_GBE_TM_TH_TX_STRT_8 |
+		PCH_GBE_TM_TH_ALM_EMP_4 | PCH_GBE_TM_TH_ALM_FULL_8;
+
+	iowrite32(tx_mode, &hw->reg->TX_MODE);
+
+	tcpip = ioread32(&hw->reg->TCPIP_ACC);
+	tcpip |= PCH_GBE_TX_TCPIPACC_EN;
+	iowrite32(tcpip, &hw->reg->TCPIP_ACC);
+	return;
+}
+
+/**
+ * pch_gbe_configure_tx - Configure Transmit Unit after Reset
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_configure_tx(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 tdba, tdlen, dctrl;
+
+	pr_debug("dma addr = 0x%08llx  size = 0x%08x\n",
+		 (unsigned long long)adapter->tx_ring->dma,
+		 adapter->tx_ring->size);
+
+	/* Setup the HW Tx Head and Tail descriptor pointers */
+	tdba = adapter->tx_ring->dma;
+	tdlen = adapter->tx_ring->size - 0x10;
+	iowrite32(tdba, &hw->reg->TX_DSC_BASE);
+	iowrite32(tdlen, &hw->reg->TX_DSC_SIZE);
+	iowrite32(tdba, &hw->reg->TX_DSC_SW_P);
+
+	/* Enables Transmission DMA */
+	dctrl = ioread32(&hw->reg->DMA_CTRL);
+	dctrl |= PCH_GBE_TX_DMA_EN;
+	iowrite32(dctrl, &hw->reg->DMA_CTRL);
+}
+
+/**
+ * pch_gbe_setup_rctl - Configure the receive control registers
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_setup_rctl(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 rx_mode, tcpip;
+
+	rx_mode = PCH_GBE_ADD_FIL_EN | PCH_GBE_MLT_FIL_EN |
+	PCH_GBE_RH_ALM_EMP_4 | PCH_GBE_RH_ALM_FULL_4 | PCH_GBE_RH_RD_TRG_8;
+
+	iowrite32(rx_mode, &hw->reg->RX_MODE);
+
+	tcpip = ioread32(&hw->reg->TCPIP_ACC);
+
+	if (adapter->rx_csum) {
+		tcpip &= ~PCH_GBE_RX_TCPIPACC_OFF;
+		tcpip |= PCH_GBE_RX_TCPIPACC_EN;
+	} else {
+		tcpip |= PCH_GBE_RX_TCPIPACC_OFF;
+		tcpip &= ~PCH_GBE_RX_TCPIPACC_EN;
+	}
+	iowrite32(tcpip, &hw->reg->TCPIP_ACC);
+	return;
+}
+
+/**
+ * pch_gbe_configure_rx - Configure Receive Unit after Reset
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_configure_rx(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 rdba, rdlen, rctl, rxdma;
+
+	pr_debug("dma adr = 0x%08llx  size = 0x%08x\n",
+		 (unsigned long long)adapter->rx_ring->dma,
+		 adapter->rx_ring->size);
+
+	pch_gbe_mac_force_mac_fc(hw);
+
+	/* Disables Receive MAC */
+	rctl = ioread32(&hw->reg->MAC_RX_EN);
+	iowrite32((rctl & ~PCH_GBE_MRE_MAC_RX_EN), &hw->reg->MAC_RX_EN);
+
+	/* Disables Receive DMA */
+	rxdma = ioread32(&hw->reg->DMA_CTRL);
+	rxdma &= ~PCH_GBE_RX_DMA_EN;
+	iowrite32(rxdma, &hw->reg->DMA_CTRL);
+
+	pr_debug("MAC_RX_EN reg = 0x%08x  DMA_CTRL reg = 0x%08x\n",
+		 ioread32(&hw->reg->MAC_RX_EN),
+		 ioread32(&hw->reg->DMA_CTRL));
+
+	/* Setup the HW Rx Head and Tail Descriptor Pointers and
+	 * the Base and Length of the Rx Descriptor Ring */
+	rdba = adapter->rx_ring->dma;
+	rdlen = adapter->rx_ring->size - 0x10;
+	iowrite32(rdba, &hw->reg->RX_DSC_BASE);
+	iowrite32(rdlen, &hw->reg->RX_DSC_SIZE);
+	iowrite32((rdba + rdlen), &hw->reg->RX_DSC_SW_P);
+
+	/* Enables Receive DMA */
+	rxdma = ioread32(&hw->reg->DMA_CTRL);
+	rxdma |= PCH_GBE_RX_DMA_EN;
+	iowrite32(rxdma, &hw->reg->DMA_CTRL);
+	/* Enables Receive */
+	iowrite32(PCH_GBE_MRE_MAC_RX_EN, &hw->reg->MAC_RX_EN);
+}
+
+/**
+ * pch_gbe_unmap_and_free_tx_resource - Unmap and free tx socket buffer
+ * @adapter:     Board private structure
+ * @buffer_info: Buffer information structure
+ */
+static void pch_gbe_unmap_and_free_tx_resource(
+	struct pch_gbe_adapter *adapter, struct pch_gbe_buffer *buffer_info)
+{
+	if (buffer_info->mapped) {
+		dma_unmap_single(&adapter->pdev->dev, buffer_info->dma,
+				 buffer_info->length, DMA_TO_DEVICE);
+		buffer_info->mapped = false;
+	}
+	if (buffer_info->skb) {
+		dev_kfree_skb_any(buffer_info->skb);
+		buffer_info->skb = NULL;
+	}
+}
+
+/**
+ * pch_gbe_unmap_and_free_rx_resource - Unmap and free rx socket buffer
+ * @adapter:      Board private structure
+ * @buffer_info:  Buffer information structure
+ */
+static void pch_gbe_unmap_and_free_rx_resource(
+					struct pch_gbe_adapter *adapter,
+					struct pch_gbe_buffer *buffer_info)
+{
+	if (buffer_info->mapped) {
+		dma_unmap_single(&adapter->pdev->dev, buffer_info->dma,
+				 buffer_info->length, DMA_FROM_DEVICE);
+		buffer_info->mapped = false;
+	}
+	if (buffer_info->skb) {
+		dev_kfree_skb_any(buffer_info->skb);
+		buffer_info->skb = NULL;
+	}
+}
+
+/**
+ * pch_gbe_clean_tx_ring - Free Tx Buffers
+ * @adapter:  Board private structure
+ * @tx_ring:  Ring to be cleaned
+ */
+static void pch_gbe_clean_tx_ring(struct pch_gbe_adapter *adapter,
+				   struct pch_gbe_tx_ring *tx_ring)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct pch_gbe_buffer *buffer_info;
+	unsigned long size;
+	unsigned int i;
+
+	/* Free all the Tx ring sk_buffs */
+	for (i = 0; i < tx_ring->count; i++) {
+		buffer_info = &tx_ring->buffer_info[i];
+		pch_gbe_unmap_and_free_tx_resource(adapter, buffer_info);
+	}
+	pr_debug("call pch_gbe_unmap_and_free_tx_resource() %d count\n", i);
+
+	size = (unsigned long)sizeof(struct pch_gbe_buffer) * tx_ring->count;
+	memset(tx_ring->buffer_info, 0, size);
+
+	/* Zero out the descriptor ring */
+	memset(tx_ring->desc, 0, tx_ring->size);
+	tx_ring->next_to_use = 0;
+	tx_ring->next_to_clean = 0;
+	iowrite32(tx_ring->dma, &hw->reg->TX_DSC_HW_P);
+	iowrite32((tx_ring->size - 0x10), &hw->reg->TX_DSC_SIZE);
+}
+
+/**
+ * pch_gbe_clean_rx_ring - Free Rx Buffers
+ * @adapter:  Board private structure
+ * @rx_ring:  Ring to free buffers from
+ */
+static void
+pch_gbe_clean_rx_ring(struct pch_gbe_adapter *adapter,
+		      struct pch_gbe_rx_ring *rx_ring)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct pch_gbe_buffer *buffer_info;
+	unsigned long size;
+	unsigned int i;
+
+	/* Free all the Rx ring sk_buffs */
+	for (i = 0; i < rx_ring->count; i++) {
+		buffer_info = &rx_ring->buffer_info[i];
+		pch_gbe_unmap_and_free_rx_resource(adapter, buffer_info);
+	}
+	pr_debug("call pch_gbe_unmap_and_free_rx_resource() %d count\n", i);
+	size = (unsigned long)sizeof(struct pch_gbe_buffer) * rx_ring->count;
+	memset(rx_ring->buffer_info, 0, size);
+
+	/* Zero out the descriptor ring */
+	memset(rx_ring->desc, 0, rx_ring->size);
+	rx_ring->next_to_clean = 0;
+	rx_ring->next_to_use = 0;
+	iowrite32(rx_ring->dma, &hw->reg->RX_DSC_HW_P);
+	iowrite32((rx_ring->size - 0x10), &hw->reg->RX_DSC_SIZE);
+}
+
+static void pch_gbe_set_rgmii_ctrl(struct pch_gbe_adapter *adapter, u16 speed,
+				    u16 duplex)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	unsigned long rgmii = 0;
+
+	/* Set the RGMII control. */
+#ifdef PCH_GBE_MAC_IFOP_RGMII
+	switch (speed) {
+	case SPEED_10:
+		rgmii = (PCH_GBE_RGMII_RATE_2_5M |
+			 PCH_GBE_MAC_RGMII_CTRL_SETTING);
+		break;
+	case SPEED_100:
+		rgmii = (PCH_GBE_RGMII_RATE_25M |
+			 PCH_GBE_MAC_RGMII_CTRL_SETTING);
+		break;
+	case SPEED_1000:
+		rgmii = (PCH_GBE_RGMII_RATE_125M |
+			 PCH_GBE_MAC_RGMII_CTRL_SETTING);
+		break;
+	}
+	iowrite32(rgmii, &hw->reg->RGMII_CTRL);
+#else	/* GMII */
+	rgmii = 0;
+	iowrite32(rgmii, &hw->reg->RGMII_CTRL);
+#endif
+}
+static void pch_gbe_set_mode(struct pch_gbe_adapter *adapter, u16 speed,
+			      u16 duplex)
+{
+	struct net_device *netdev = adapter->netdev;
+	struct pch_gbe_hw *hw = &adapter->hw;
+	unsigned long mode = 0;
+
+	/* Set the communication mode */
+	switch (speed) {
+	case SPEED_10:
+		mode = PCH_GBE_MODE_MII_ETHER;
+		netdev->tx_queue_len = 10;
+		break;
+	case SPEED_100:
+		mode = PCH_GBE_MODE_MII_ETHER;
+		netdev->tx_queue_len = 100;
+		break;
+	case SPEED_1000:
+		mode = PCH_GBE_MODE_GMII_ETHER;
+		break;
+	}
+	if (duplex == DUPLEX_FULL)
+		mode |= PCH_GBE_MODE_FULL_DUPLEX;
+	else
+		mode |= PCH_GBE_MODE_HALF_DUPLEX;
+	iowrite32(mode, &hw->reg->MODE);
+}
+
+/**
+ * pch_gbe_watchdog - Watchdog process
+ * @data:  Board private structure
+ */
+static void pch_gbe_watchdog(unsigned long data)
+{
+	struct pch_gbe_adapter *adapter = (struct pch_gbe_adapter *)data;
+	struct net_device *netdev = adapter->netdev;
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct ethtool_cmd cmd;
+
+	pr_debug("right now = %ld\n", jiffies);
+
+	pch_gbe_update_stats(adapter);
+	if ((mii_link_ok(&adapter->mii)) && (!netif_carrier_ok(netdev))) {
+		netdev->tx_queue_len = adapter->tx_queue_len;
+		/* mii library handles link maintenance tasks */
+		if (mii_ethtool_gset(&adapter->mii, &cmd)) {
+			pr_err("ethtool get setting Error\n");
+			mod_timer(&adapter->watchdog_timer,
+				  round_jiffies(jiffies +
+						PCH_GBE_WATCHDOG_PERIOD));
+			return;
+		}
+		hw->mac.link_speed = cmd.speed;
+		hw->mac.link_duplex = cmd.duplex;
+		/* Set the RGMII control. */
+		pch_gbe_set_rgmii_ctrl(adapter, hw->mac.link_speed,
+						hw->mac.link_duplex);
+		/* Set the communication mode */
+		pch_gbe_set_mode(adapter, hw->mac.link_speed,
+				 hw->mac.link_duplex);
+		netdev_dbg(netdev,
+			   "Link is Up %d Mbps %s-Duplex\n",
+			   cmd.speed,
+			   cmd.duplex == DUPLEX_FULL ? "Full" : "Half");
+		netif_carrier_on(netdev);
+		netif_wake_queue(netdev);
+	} else if ((!mii_link_ok(&adapter->mii)) &&
+		   (netif_carrier_ok(netdev))) {
+		netdev_dbg(netdev, "NIC Link is Down\n");
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		netif_carrier_off(netdev);
+		netif_stop_queue(netdev);
+	}
+	mod_timer(&adapter->watchdog_timer,
+		  round_jiffies(jiffies + PCH_GBE_WATCHDOG_PERIOD));
+}
+
+/**
+ * pch_gbe_tx_queue - Carry out queuing of the transmission data
+ * @adapter:  Board private structure
+ * @tx_ring:  Tx descriptor ring structure
+ * @skb:      Sockt buffer structure
+ */
+static void pch_gbe_tx_queue(struct pch_gbe_adapter *adapter,
+			      struct pch_gbe_tx_ring *tx_ring,
+			      struct sk_buff *skb)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct pch_gbe_tx_desc *tx_desc;
+	struct pch_gbe_buffer *buffer_info;
+	struct sk_buff *tmp_skb;
+	unsigned int frame_ctrl;
+	unsigned int ring_num;
+	unsigned long flags;
+
+	/*-- Set frame control --*/
+	frame_ctrl = 0;
+	if (unlikely(skb->len < PCH_GBE_SHORT_PKT))
+		frame_ctrl |= PCH_GBE_TXD_CTRL_APAD;
+	if (unlikely(!adapter->tx_csum))
+		frame_ctrl |= PCH_GBE_TXD_CTRL_TCPIP_ACC_OFF;
+
+	/* Performs checksum processing */
+	/*
+	 * It is because the hardware accelerator does not support a checksum,
+	 * when the received data size is less than 64 bytes.
+	 */
+	if ((skb->len < PCH_GBE_SHORT_PKT) && (adapter->tx_csum)) {
+		frame_ctrl |= PCH_GBE_TXD_CTRL_APAD |
+			      PCH_GBE_TXD_CTRL_TCPIP_ACC_OFF;
+		if (skb->protocol == htons(ETH_P_IP)) {
+			struct iphdr *iph = ip_hdr(skb);
+			unsigned int offset;
+			iph->check = 0;
+			iph->check = ip_fast_csum((u8 *) iph, iph->ihl);
+			offset = skb_transport_offset(skb);
+			if (iph->protocol == IPPROTO_TCP) {
+				skb->csum = 0;
+				tcp_hdr(skb)->check = 0;
+				skb->csum = skb_checksum(skb, offset,
+							 skb->len - offset, 0);
+				tcp_hdr(skb)->check =
+					csum_tcpudp_magic(iph->saddr,
+							  iph->daddr,
+							  skb->len - offset,
+							  IPPROTO_TCP,
+							  skb->csum);
+			} else if (iph->protocol == IPPROTO_UDP) {
+				skb->csum = 0;
+				udp_hdr(skb)->check = 0;
+				skb->csum =
+					skb_checksum(skb, offset,
+						     skb->len - offset, 0);
+				udp_hdr(skb)->check =
+					csum_tcpudp_magic(iph->saddr,
+							  iph->daddr,
+							  skb->len - offset,
+							  IPPROTO_UDP,
+							  skb->csum);
+			}
+		}
+	}
+	spin_lock_irqsave(&tx_ring->tx_lock, flags);
+	ring_num = tx_ring->next_to_use;
+	if (unlikely((ring_num + 1) == tx_ring->count))
+		tx_ring->next_to_use = 0;
+	else
+		tx_ring->next_to_use = ring_num + 1;
+
+	spin_unlock_irqrestore(&tx_ring->tx_lock, flags);
+	buffer_info = &tx_ring->buffer_info[ring_num];
+	tmp_skb = buffer_info->skb;
+
+	/* [Header:14][payload] ---> [Header:14][paddong:2][payload]    */
+	memcpy(tmp_skb->data, skb->data, ETH_HLEN);
+	tmp_skb->data[ETH_HLEN] = 0x00;
+	tmp_skb->data[ETH_HLEN + 1] = 0x00;
+	tmp_skb->len = skb->len;
+	memcpy(&tmp_skb->data[ETH_HLEN + 2], &skb->data[ETH_HLEN],
+	       (skb->len - ETH_HLEN));
+	/*-- Set Buffer infomation --*/
+	buffer_info->length = tmp_skb->len;
+	buffer_info->dma = dma_map_single(&adapter->pdev->dev, tmp_skb->data,
+					  buffer_info->length,
+					  DMA_TO_DEVICE);
+//	if (dma_mapping_error(&adapter->pdev->dev, buffer_info->dma)) {
+//		pr_err("TX DMA map failed\n");
+//		buffer_info->dma = 0;
+//		buffer_info->time_stamp = 0;
+//		tx_ring->next_to_use = ring_num;
+//		return;
+//	}
+	buffer_info->mapped = true;
+	buffer_info->time_stamp = jiffies;
+
+	/*-- Set Tx descriptor --*/
+	tx_desc = PCH_GBE_TX_DESC(*tx_ring, ring_num);
+	tx_desc->buffer_addr = (buffer_info->dma);
+	tx_desc->length = (tmp_skb->len);
+	tx_desc->tx_words_eob = ((tmp_skb->len + 3));
+	tx_desc->tx_frame_ctrl = (frame_ctrl);
+	tx_desc->gbec_status = (DSC_INIT16);
+
+	if (unlikely(++ring_num == tx_ring->count))
+		ring_num = 0;
+
+	/* Update software pointer of TX descriptor */
+	iowrite32(tx_ring->dma +
+		  (int)sizeof(struct pch_gbe_tx_desc) * ring_num,
+		  &hw->reg->TX_DSC_SW_P);
+	dev_kfree_skb_any(skb);
+}
+
+/**
+ * pch_gbe_update_stats - Update the board statistics counters
+ * @adapter:  Board private structure
+ */
+void pch_gbe_update_stats(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+	struct pci_dev *pdev = adapter->pdev;
+	struct pch_gbe_hw_stats *stats = &adapter->stats;
+	unsigned long flags;
+
+	/*
+	 * Prevent stats update while adapter is being reset, or if the pci
+	 * connection is down.
+	 */
+	if ((pdev->error_state) && (pdev->error_state != pci_channel_io_normal))
+		return;
+
+	spin_lock_irqsave(&adapter->stats_lock, flags);
+
+	/* Update device status "adapter->stats" */
+	stats->rx_errors = stats->rx_crc_errors + stats->rx_frame_errors;
+	stats->tx_errors = stats->tx_length_errors +
+	    stats->tx_aborted_errors +
+	    stats->tx_carrier_errors + stats->tx_timeout_count;
+
+	/* Update network device status "adapter->net_stats" */
+	netdev->stats.rx_packets = stats->rx_packets;
+	netdev->stats.rx_bytes = stats->rx_bytes;
+	netdev->stats.rx_dropped = stats->rx_dropped;
+	netdev->stats.tx_packets = stats->tx_packets;
+	netdev->stats.tx_bytes = stats->tx_bytes;
+	netdev->stats.tx_dropped = stats->tx_dropped;
+	/* Fill out the OS statistics structure */
+	netdev->stats.multicast = stats->multicast;
+	netdev->stats.collisions = stats->collisions;
+	/* Rx Errors */
+	netdev->stats.rx_errors = stats->rx_errors;
+	netdev->stats.rx_crc_errors = stats->rx_crc_errors;
+	netdev->stats.rx_frame_errors = stats->rx_frame_errors;
+	/* Tx Errors */
+	netdev->stats.tx_errors = stats->tx_errors;
+	netdev->stats.tx_aborted_errors = stats->tx_aborted_errors;
+	netdev->stats.tx_carrier_errors = stats->tx_carrier_errors;
+
+	spin_unlock_irqrestore(&adapter->stats_lock, flags);
+}
+
+/**
+ * pch_gbe_intr - Interrupt Handler
+ * @irq:   Interrupt number
+ * @data:  Pointer to a network interface device structure
+ * Returns
+ *	- IRQ_HANDLED:	Our interrupt
+ *	- IRQ_NONE:	Not our interrupt
+ */
+static irqreturn_t pch_gbe_intr(int irq, void *data)
+{
+	struct net_device *netdev = data;
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 int_st;
+	u32 int_en;
+
+	/* Check request status */
+	int_st = ioread32(&hw->reg->INT_ST);
+	int_st = int_st & ioread32(&hw->reg->INT_EN);
+	/* When request status is no interruption factor */
+	if (unlikely(!int_st))
+		return IRQ_NONE;	/* Not our interrupt. End processing. */
+	pr_debug("%s occur int_st = 0x%08x\n", __func__, int_st);
+	if (int_st & PCH_GBE_INT_RX_FRAME_ERR)
+		adapter->stats.intr_rx_frame_err_count++;
+	if (int_st & PCH_GBE_INT_RX_FIFO_ERR)
+		adapter->stats.intr_rx_fifo_err_count++;
+	if (int_st & PCH_GBE_INT_RX_DMA_ERR)
+		adapter->stats.intr_rx_dma_err_count++;
+	if (int_st & PCH_GBE_INT_TX_FIFO_ERR)
+		adapter->stats.intr_tx_fifo_err_count++;
+	if (int_st & PCH_GBE_INT_TX_DMA_ERR)
+		adapter->stats.intr_tx_dma_err_count++;
+	if (int_st & PCH_GBE_INT_TCPIP_ERR)
+		adapter->stats.intr_tcpip_err_count++;
+	/* When Rx descriptor is empty  */
+	if ((int_st & PCH_GBE_INT_RX_DSC_EMP)) {
+		adapter->stats.intr_rx_dsc_empty_count++;
+		pr_err("Rx descriptor is empty\n");
+		int_en = ioread32(&hw->reg->INT_EN);
+		iowrite32((int_en & ~PCH_GBE_INT_RX_DSC_EMP), &hw->reg->INT_EN);
+		if (hw->mac.tx_fc_enable) {
+			/* Set Pause packet */
+			pch_gbe_mac_set_pause_packet(hw);
+		}
+		if ((int_en & (PCH_GBE_INT_RX_DMA_CMPLT | PCH_GBE_INT_TX_CMPLT))
+		    == 0) {
+			return IRQ_HANDLED;
+		}
+	}
+
+	/* When request status is Receive interruption */
+	if ((int_st & (PCH_GBE_INT_RX_DMA_CMPLT | PCH_GBE_INT_TX_CMPLT))) {
+//		if (likely(napi_schedule_prep(&adapter->napi))) {
+//			/* Enable only Rx Descriptor empty */
+//			atomic_inc(&adapter->irq_sem);
+//			int_en = ioread32(&hw->reg->INT_EN);
+//			int_en &=
+//			    ~(PCH_GBE_INT_RX_DMA_CMPLT | PCH_GBE_INT_TX_CMPLT);
+//			iowrite32(int_en, &hw->reg->INT_EN);
+//			/* Start polling for NAPI */
+//			__napi_schedule(&adapter->napi);
+//		}
+	}
+	pr_debug("return = 0x%08x  INT_EN reg = 0x%08x\n",
+		 IRQ_HANDLED, ioread32(&hw->reg->INT_EN));
+	return IRQ_HANDLED;
+}
+
+/**
+ * pch_gbe_alloc_rx_buffers - Replace used receive buffers; legacy & extended
+ * @adapter:       Board private structure
+ * @rx_ring:       Rx descriptor ring
+ * @cleaned_count: Cleaned count
+ */
+static void
+pch_gbe_alloc_rx_buffers(struct pch_gbe_adapter *adapter,
+			 struct pch_gbe_rx_ring *rx_ring, int cleaned_count)
+{
+	struct net_device *netdev = adapter->netdev;
+	struct pci_dev *pdev = adapter->pdev;
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct pch_gbe_rx_desc *rx_desc;
+	struct pch_gbe_buffer *buffer_info;
+	struct sk_buff *skb;
+	unsigned int i;
+	unsigned int bufsz;
+
+	bufsz = adapter->rx_buffer_len + PCH_GBE_DMA_ALIGN;
+	i = rx_ring->next_to_use;
+
+	while ((cleaned_count--)) {
+		buffer_info = &rx_ring->buffer_info[i];
+		skb = buffer_info->skb;
+		if (skb) {
+			skb_trim(skb, 0);
+		} else {
+			skb = netdev_alloc_skb(netdev, bufsz);
+			if (unlikely(!skb)) {
+				/* Better luck next round */
+				adapter->stats.rx_alloc_buff_failed++;
+				break;
+			}
+			/* 64byte align */
+			skb_reserve(skb, PCH_GBE_DMA_ALIGN);
+
+			buffer_info->skb = skb;
+			buffer_info->length = adapter->rx_buffer_len;
+		}
+		buffer_info->dma = dma_map_single(&pdev->dev,
+						  skb->data,
+						  buffer_info->length,
+						  DMA_FROM_DEVICE);
+//		if (dma_mapping_error(&adapter->pdev->dev, buffer_info->dma)) {
+//			dev_kfree_skb(skb);
+//			buffer_info->skb = NULL;
+//			buffer_info->dma = 0;
+//			adapter->stats.rx_alloc_buff_failed++;
+//			break; /* while !buffer_info->skb */
+//		}
+		buffer_info->mapped = true;
+		rx_desc = PCH_GBE_RX_DESC(*rx_ring, i);
+		rx_desc->buffer_addr = (buffer_info->dma);
+		rx_desc->gbec_status = DSC_INIT16;
+
+		pr_debug("i = %d  buffer_info->dma = 0x08%llx  buffer_info->length = 0x%x\n",
+			 i, (unsigned long long)buffer_info->dma,
+			 buffer_info->length);
+
+		if (unlikely(++i == rx_ring->count))
+			i = 0;
+	}
+	if (likely(rx_ring->next_to_use != i)) {
+		rx_ring->next_to_use = i;
+		if (unlikely(i-- == 0))
+			i = (rx_ring->count - 1);
+		iowrite32(rx_ring->dma +
+			  (int)sizeof(struct pch_gbe_rx_desc) * i,
+			  &hw->reg->RX_DSC_SW_P);
+	}
+	return;
+}
+
+/**
+ * pch_gbe_alloc_tx_buffers - Allocate transmit buffers
+ * @adapter:   Board private structure
+ * @tx_ring:   Tx descriptor ring
+ */
+static void pch_gbe_alloc_tx_buffers(struct pch_gbe_adapter *adapter,
+					struct pch_gbe_tx_ring *tx_ring)
+{
+	struct pch_gbe_buffer *buffer_info;
+	struct sk_buff *skb;
+	unsigned int i;
+	unsigned int bufsz;
+	struct pch_gbe_tx_desc *tx_desc;
+
+	bufsz =
+	    adapter->hw.mac.max_frame_size + PCH_GBE_DMA_ALIGN + NET_IP_ALIGN;
+
+	for (i = 0; i < tx_ring->count; i++) {
+		buffer_info = &tx_ring->buffer_info[i];
+		skb = netdev_alloc_skb(adapter->netdev, bufsz);
+		skb_reserve(skb, PCH_GBE_DMA_ALIGN);
+		buffer_info->skb = skb;
+		tx_desc = PCH_GBE_TX_DESC(*tx_ring, i);
+		tx_desc->gbec_status = (DSC_INIT16);
+	}
+	return;
+}
+
+/**
+ * pch_gbe_clean_tx - Reclaim resources after transmit completes
+ * @adapter:   Board private structure
+ * @tx_ring:   Tx descriptor ring
+ * Returns
+ *	true:  Cleaned the descriptor
+ *	false: Not cleaned the descriptor
+ */
+static bool
+pch_gbe_clean_tx(struct pch_gbe_adapter *adapter,
+		 struct pch_gbe_tx_ring *tx_ring)
+{
+	struct pch_gbe_tx_desc *tx_desc;
+	struct pch_gbe_buffer *buffer_info;
+	struct sk_buff *skb;
+	unsigned int i;
+	unsigned int cleaned_count = 0;
+	bool cleaned = false;
+
+	pr_debug("next_to_clean : %d\n", tx_ring->next_to_clean);
+
+	i = tx_ring->next_to_clean;
+	tx_desc = PCH_GBE_TX_DESC(*tx_ring, i);
+	pr_debug("gbec_status:0x%04x  dma_status:0x%04x\n",
+		 tx_desc->gbec_status, tx_desc->dma_status);
+
+	while ((tx_desc->gbec_status & DSC_INIT16) == 0x0000) {
+		pr_debug("gbec_status:0x%04x\n", tx_desc->gbec_status);
+		cleaned = true;
+		buffer_info = &tx_ring->buffer_info[i];
+		skb = buffer_info->skb;
+
+		if ((tx_desc->gbec_status & PCH_GBE_TXD_GMAC_STAT_ABT)) {
+			adapter->stats.tx_aborted_errors++;
+			pr_err("Transfer Abort Error\n");
+		} else if ((tx_desc->gbec_status & PCH_GBE_TXD_GMAC_STAT_CRSER)
+			  ) {
+			adapter->stats.tx_carrier_errors++;
+			pr_err("Transfer Carrier Sense Error\n");
+		} else if ((tx_desc->gbec_status & PCH_GBE_TXD_GMAC_STAT_EXCOL)
+			  ) {
+			adapter->stats.tx_aborted_errors++;
+			pr_err("Transfer Collision Abort Error\n");
+		} else if ((tx_desc->gbec_status &
+			    (PCH_GBE_TXD_GMAC_STAT_SNGCOL |
+			     PCH_GBE_TXD_GMAC_STAT_MLTCOL))) {
+			adapter->stats.collisions++;
+			adapter->stats.tx_packets++;
+			adapter->stats.tx_bytes += skb->len;
+			pr_debug("Transfer Collision\n");
+		} else if ((tx_desc->gbec_status & PCH_GBE_TXD_GMAC_STAT_CMPLT)
+			  ) {
+			adapter->stats.tx_packets++;
+			adapter->stats.tx_bytes += skb->len;
+		}
+		if (buffer_info->mapped) {
+			pr_debug("unmap buffer_info->dma : %d\n", i);
+			dma_unmap_single(&adapter->pdev->dev, buffer_info->dma,
+					 buffer_info->length, DMA_TO_DEVICE);
+			buffer_info->mapped = false;
+		}
+		if (buffer_info->skb) {
+			pr_debug("trim buffer_info->skb : %d\n", i);
+			skb_trim(buffer_info->skb, 0);
+		}
+		tx_desc->gbec_status = DSC_INIT16;
+		if (unlikely(++i == tx_ring->count))
+			i = 0;
+		tx_desc = PCH_GBE_TX_DESC(*tx_ring, i);
+
+		/* weight of a sort for tx, to avoid endless transmit cleanup */
+		if (cleaned_count++ == PCH_GBE_TX_WEIGHT)
+			break;
+	}
+	pr_debug("called pch_gbe_unmap_and_free_tx_resource() %d count\n",
+		 cleaned_count);
+	/* Recover from running out of Tx resources in xmit_frame */
+	if (unlikely(cleaned && (netif_queue_stopped(adapter->netdev)))) {
+		netif_wake_queue(adapter->netdev);
+		adapter->stats.tx_restart_count++;
+		pr_debug("Tx wake queue\n");
+	}
+	spin_lock(&adapter->tx_queue_lock);
+	tx_ring->next_to_clean = i;
+	spin_unlock(&adapter->tx_queue_lock);
+	pr_debug("next_to_clean : %d\n", tx_ring->next_to_clean);
+	return cleaned;
+}
+
+/**
+ * pch_gbe_clean_rx - Send received data up the network stack; legacy
+ * @adapter:     Board private structure
+ * @rx_ring:     Rx descriptor ring
+ * @work_done:   Completed count
+ * @work_to_do:  Request count
+ * Returns
+ *	true:  Cleaned the descriptor
+ *	false: Not cleaned the descriptor
+ */
+static bool
+pch_gbe_clean_rx(struct pch_gbe_adapter *adapter,
+		 struct pch_gbe_rx_ring *rx_ring,
+		 int *work_done, int work_to_do)
+{
+	struct net_device *netdev = adapter->netdev;
+	struct pci_dev *pdev = adapter->pdev;
+	struct pch_gbe_buffer *buffer_info;
+	struct pch_gbe_rx_desc *rx_desc;
+	u32 length;
+	unsigned int i;
+	unsigned int cleaned_count = 0;
+	bool cleaned = false;
+	struct sk_buff *skb, *new_skb;
+	u8 dma_status;
+	u16 gbec_status;
+	u32 tcp_ip_status;
+
+	i = rx_ring->next_to_clean;
+
+	while (*work_done < work_to_do) {
+		/* Check Rx descriptor status */
+		rx_desc = PCH_GBE_RX_DESC(*rx_ring, i);
+		if (rx_desc->gbec_status == DSC_INIT16)
+			break;
+		cleaned = true;
+		cleaned_count++;
+
+		dma_status = rx_desc->dma_status;
+		gbec_status = rx_desc->gbec_status;
+		tcp_ip_status = rx_desc->tcp_ip_status;
+		rx_desc->gbec_status = DSC_INIT16;
+		buffer_info = &rx_ring->buffer_info[i];
+		skb = buffer_info->skb;
+
+		/* unmap dma */
+		dma_unmap_single(&pdev->dev, buffer_info->dma,
+				   buffer_info->length, DMA_FROM_DEVICE);
+		buffer_info->mapped = false;
+		/* Prefetch the packet */
+		prefetch(skb->data);
+
+		pr_debug("RxDecNo = 0x%04x  Status[DMA:0x%02x GBE:0x%04x "
+			 "TCP:0x%08x]  BufInf = 0x%p\n",
+			 i, dma_status, gbec_status, tcp_ip_status,
+			 buffer_info);
+		/* Error check */
+		if (unlikely(gbec_status & PCH_GBE_RXD_GMAC_STAT_NOTOCTAL)) {
+			adapter->stats.rx_frame_errors++;
+			pr_err("Receive Not Octal Error\n");
+		} else if (unlikely(gbec_status &
+				PCH_GBE_RXD_GMAC_STAT_NBLERR)) {
+			adapter->stats.rx_frame_errors++;
+			pr_err("Receive Nibble Error\n");
+		} else if (unlikely(gbec_status &
+				PCH_GBE_RXD_GMAC_STAT_CRCERR)) {
+			adapter->stats.rx_crc_errors++;
+			pr_err("Receive CRC Error\n");
+		} else {
+			/* get receive length */
+			/* length convert[-3] */
+			length = (rx_desc->rx_words_eob) - 3;
+
+			/* Decide the data conversion method */
+			if (!adapter->rx_csum) {
+				/* [Header:14][payload] */
+				if (NET_IP_ALIGN) {
+					/* Because alignment differs,
+					 * the new_skb is newly allocated,
+					 * and data is copied to new_skb.*/
+					new_skb = netdev_alloc_skb(netdev,
+							 length + NET_IP_ALIGN);
+					if (!new_skb) {
+						/* dorrop error */
+						pr_err("New skb allocation "
+							"Error\n");
+						goto dorrop;
+					}
+					skb_reserve(new_skb, NET_IP_ALIGN);
+					memcpy(new_skb->data, skb->data,
+					       length);
+					skb = new_skb;
+				} else {
+					/* DMA buffer is used as SKB as it is.*/
+					buffer_info->skb = NULL;
+				}
+			} else {
+				/* [Header:14][padding:2][payload] */
+				/* The length includes padding length */
+				length = length - PCH_GBE_DMA_PADDING;
+				if ((length < copybreak) ||
+				    (NET_IP_ALIGN != PCH_GBE_DMA_PADDING)) {
+					/* Because alignment differs,
+					 * the new_skb is newly allocated,
+					 * and data is copied to new_skb.
+					 * Padding data is deleted
+					 * at the time of a copy.*/
+					new_skb = netdev_alloc_skb(netdev,
+							 length + NET_IP_ALIGN);
+					if (!new_skb) {
+						/* dorrop error */
+						pr_err("New skb allocation "
+							"Error\n");
+						goto dorrop;
+					}
+					skb_reserve(new_skb, NET_IP_ALIGN);
+					memcpy(new_skb->data, skb->data,
+					       ETH_HLEN);
+					memcpy(&new_skb->data[ETH_HLEN],
+					       &skb->data[ETH_HLEN +
+					       PCH_GBE_DMA_PADDING],
+					       length - ETH_HLEN);
+					skb = new_skb;
+				} else {
+					/* Padding data is deleted
+					 * by moving header data.*/
+					memmove(&skb->data[PCH_GBE_DMA_PADDING],
+						&skb->data[0], ETH_HLEN);
+					skb_reserve(skb, NET_IP_ALIGN);
+					buffer_info->skb = NULL;
+				}
+			}
+			/* The length includes FCS length */
+			length = length - ETH_FCS_LEN;
+			/* update status of driver */
+			adapter->stats.rx_bytes += length;
+			adapter->stats.rx_packets++;
+			if ((gbec_status & PCH_GBE_RXD_GMAC_STAT_MARMLT))
+				adapter->stats.multicast++;
+			/* Write meta date of skb */
+			skb_put(skb, length);
+			skb->protocol = eth_type_trans(skb, netdev);
+			if ((tcp_ip_status & PCH_GBE_RXD_ACC_STAT_TCPIPOK) ==
+			    PCH_GBE_RXD_ACC_STAT_TCPIPOK) {
+				skb->ip_summed = CHECKSUM_UNNECESSARY;
+			} else {
+				skb->ip_summed = CHECKSUM_NONE;
+			}
+			napi_gro_receive(&adapter->napi, skb);
+			(*work_done)++;
+			pr_debug("Receive skb->ip_summed: %d length: %d\n",
+				 skb->ip_summed, length);
+		}
+dorrop:
+		/* return some buffers to hardware, one at a time is too slow */
+		if (unlikely(cleaned_count >= PCH_GBE_RX_BUFFER_WRITE)) {
+			pch_gbe_alloc_rx_buffers(adapter, rx_ring,
+						 cleaned_count);
+			cleaned_count = 0;
+		}
+		if (++i == rx_ring->count)
+			i = 0;
+	}
+	rx_ring->next_to_clean = i;
+	if (cleaned_count)
+		pch_gbe_alloc_rx_buffers(adapter, rx_ring, cleaned_count);
+	return cleaned;
+}
+
+/**
+ * pch_gbe_setup_tx_resources - Allocate Tx resources (Descriptors)
+ * @adapter:  Board private structure
+ * @tx_ring:  Tx descriptor ring (for a specific queue) to setup
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+int pch_gbe_setup_tx_resources(struct pch_gbe_adapter *adapter,
+				struct pch_gbe_tx_ring *tx_ring)
+{
+	struct pci_dev *pdev = adapter->pdev;
+	struct pch_gbe_tx_desc *tx_desc;
+	int size;
+	int desNo;
+
+	size = (int)sizeof(struct pch_gbe_buffer) * tx_ring->count;
+	tx_ring->buffer_info = vzalloc(size);
+	if (!tx_ring->buffer_info) {
+		pr_err("Unable to allocate memory for the buffer infomation\n");
+		return -ENOMEM;
+	}
+
+	tx_ring->size = tx_ring->count * (int)sizeof(struct pch_gbe_tx_desc);
+
+	tx_ring->desc = dma_alloc_coherent(&pdev->dev, tx_ring->size,
+					   &tx_ring->dma, GFP_KERNEL);
+	if (!tx_ring->desc) {
+		vfree(tx_ring->buffer_info);
+		pr_err("Unable to allocate memory for the transmit descriptor ring\n");
+		return -ENOMEM;
+	}
+	memset(tx_ring->desc, 0, tx_ring->size);
+
+	tx_ring->next_to_use = 0;
+	tx_ring->next_to_clean = 0;
+	spin_lock_init(&tx_ring->tx_lock);
+
+	for (desNo = 0; desNo < tx_ring->count; desNo++) {
+		tx_desc = PCH_GBE_TX_DESC(*tx_ring, desNo);
+		tx_desc->gbec_status = DSC_INIT16;
+	}
+	pr_debug("tx_ring->desc = 0x%p  tx_ring->dma = 0x%08llx\n"
+		 "next_to_clean = 0x%08x  next_to_use = 0x%08x\n",
+		 tx_ring->desc, (unsigned long long)tx_ring->dma,
+		 tx_ring->next_to_clean, tx_ring->next_to_use);
+	return 0;
+}
+
+/**
+ * pch_gbe_setup_rx_resources - Allocate Rx resources (Descriptors)
+ * @adapter:  Board private structure
+ * @rx_ring:  Rx descriptor ring (for a specific queue) to setup
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+int pch_gbe_setup_rx_resources(struct pch_gbe_adapter *adapter,
+				struct pch_gbe_rx_ring *rx_ring)
+{
+	struct pci_dev *pdev = adapter->pdev;
+	struct pch_gbe_rx_desc *rx_desc;
+	int size;
+	int desNo;
+
+	size = (int)sizeof(struct pch_gbe_buffer) * rx_ring->count;
+	rx_ring->buffer_info = vzalloc(size);
+	if (!rx_ring->buffer_info) {
+		pr_err("Unable to allocate memory for the receive descriptor ring\n");
+		return -ENOMEM;
+	}
+	rx_ring->size = rx_ring->count * (int)sizeof(struct pch_gbe_rx_desc);
+	rx_ring->desc =	dma_alloc_coherent(&pdev->dev, rx_ring->size,
+					   &rx_ring->dma, GFP_KERNEL);
+
+	if (!rx_ring->desc) {
+		pr_err("Unable to allocate memory for the receive descriptor ring\n");
+		vfree(rx_ring->buffer_info);
+		return -ENOMEM;
+	}
+	memset(rx_ring->desc, 0, rx_ring->size);
+	rx_ring->next_to_clean = 0;
+	rx_ring->next_to_use = 0;
+	for (desNo = 0; desNo < rx_ring->count; desNo++) {
+		rx_desc = PCH_GBE_RX_DESC(*rx_ring, desNo);
+		rx_desc->gbec_status = DSC_INIT16;
+	}
+	pr_debug("rx_ring->desc = 0x%p  rx_ring->dma = 0x%08llx "
+		 "next_to_clean = 0x%08x  next_to_use = 0x%08x\n",
+		 rx_ring->desc, (unsigned long long)rx_ring->dma,
+		 rx_ring->next_to_clean, rx_ring->next_to_use);
+	return 0;
+}
+
+/**
+ * pch_gbe_free_tx_resources - Free Tx Resources
+ * @adapter:  Board private structure
+ * @tx_ring:  Tx descriptor ring for a specific queue
+ */
+void pch_gbe_free_tx_resources(struct pch_gbe_adapter *adapter,
+				struct pch_gbe_tx_ring *tx_ring)
+{
+	struct pci_dev *pdev = adapter->pdev;
+
+	pch_gbe_clean_tx_ring(adapter, tx_ring);
+	vfree(tx_ring->buffer_info);
+	tx_ring->buffer_info = NULL;
+	pci_free_consistent(pdev, tx_ring->size, tx_ring->desc, tx_ring->dma);
+	tx_ring->desc = NULL;
+}
+
+/**
+ * pch_gbe_free_rx_resources - Free Rx Resources
+ * @adapter:  Board private structure
+ * @rx_ring:  Ring to clean the resources from
+ */
+void pch_gbe_free_rx_resources(struct pch_gbe_adapter *adapter,
+				struct pch_gbe_rx_ring *rx_ring)
+{
+	struct pci_dev *pdev = adapter->pdev;
+
+	pch_gbe_clean_rx_ring(adapter, rx_ring);
+	vfree(rx_ring->buffer_info);
+	rx_ring->buffer_info = NULL;
+	pci_free_consistent(pdev, rx_ring->size, rx_ring->desc, rx_ring->dma);
+	rx_ring->desc = NULL;
+}
+
+/**
+ * pch_gbe_request_irq - Allocate an interrupt line
+ * @adapter:  Board private structure
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_request_irq(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+	int err;
+	int flags;
+
+	flags = IRQF_SHARED;
+	adapter->have_msi = false;
+	err = pci_enable_msi(adapter->pdev);
+	pr_debug("call pci_enable_msi\n");
+	if (err) {
+		pr_debug("call pci_enable_msi - Error: %d\n", err);
+	} else {
+		flags = 0;
+		adapter->have_msi = true;
+	}
+	err = request_irq(adapter->pdev->irq, (void*)&pch_gbe_intr,
+			  flags, netdev->name, netdev);
+	if (err)
+		pr_err("Unable to allocate interrupt Error: %d\n", err);
+	pr_debug("adapter->have_msi : %d  flags : 0x%04x  return : 0x%04x\n",
+		 adapter->have_msi, flags, err);
+	return err;
+}
+
+
+static void pch_gbe_set_multi(struct net_device *netdev);
+/**
+ * pch_gbe_up - Up GbE network device
+ * @adapter:  Board private structure
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+int pch_gbe_up(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+	struct pch_gbe_tx_ring *tx_ring = adapter->tx_ring;
+	struct pch_gbe_rx_ring *rx_ring = adapter->rx_ring;
+	int err;
+
+	/* hardware has been reset, we need to reload some things */
+	pch_gbe_set_multi(netdev);
+
+	pch_gbe_setup_tctl(adapter);
+	pch_gbe_configure_tx(adapter);
+	pch_gbe_setup_rctl(adapter);
+	pch_gbe_configure_rx(adapter);
+
+	err = pch_gbe_request_irq(adapter);
+	if (err) {
+		pr_err("Error: can't bring device up\n");
+		return err;
+	}
+	pch_gbe_alloc_tx_buffers(adapter, tx_ring);
+	pch_gbe_alloc_rx_buffers(adapter, rx_ring, rx_ring->count);
+	adapter->tx_queue_len = netdev->tx_queue_len;
+
+	mod_timer(&adapter->watchdog_timer, jiffies);
+
+	napi_enable(&adapter->napi);
+	pch_gbe_irq_enable(adapter);
+	netif_start_queue(adapter->netdev);
+
+	return 0;
+}
+
+/**
+ * pch_gbe_down - Down GbE network device
+ * @adapter:  Board private structure
+ */
+void pch_gbe_down(struct pch_gbe_adapter *adapter)
+{
+	struct net_device *netdev = adapter->netdev;
+
+	/* signal that we're down so the interrupt handler does not
+	 * reschedule our watchdog timer */
+	napi_disable(&adapter->napi);
+	atomic_set(&adapter->irq_sem, 0);
+
+	pch_gbe_irq_disable(adapter);
+	pch_gbe_free_irq(adapter);
+
+	del_timer_sync(&adapter->watchdog_timer);
+
+	netdev->tx_queue_len = adapter->tx_queue_len;
+	netif_carrier_off(netdev);
+	netif_stop_queue(netdev);
+
+	pch_gbe_reset(adapter);
+	pch_gbe_clean_tx_ring(adapter, adapter->tx_ring);
+	pch_gbe_clean_rx_ring(adapter, adapter->rx_ring);
+}
+
+/**
+ * pch_gbe_sw_init - Initialize general software structures (struct pch_gbe_adapter)
+ * @adapter:  Board private structure to initialize
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_sw_init(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct net_device *netdev = adapter->netdev;
+
+	adapter->rx_buffer_len = PCH_GBE_FRAME_SIZE_2048;
+	hw->mac.max_frame_size = netdev->mtu + ETH_HLEN + ETH_FCS_LEN;
+	hw->mac.min_frame_size = ETH_ZLEN + ETH_FCS_LEN;
+
+	/* Initialize the hardware-specific values */
+	if (pch_gbe_hal_setup_init_funcs(hw)) {
+		pr_err("Hardware Initialization Failure\n");
+		return -EIO;
+	}
+	if (pch_gbe_alloc_queues(adapter)) {
+		pr_err("Unable to allocate memory for queues\n");
+		return -ENOMEM;
+	}
+	spin_lock_init(&adapter->hw.miim_lock);
+	spin_lock_init(&adapter->tx_queue_lock);
+	spin_lock_init(&adapter->stats_lock);
+	spin_lock_init(&adapter->ethtool_lock);
+	atomic_set(&adapter->irq_sem, 0);
+	pch_gbe_irq_disable(adapter);
+
+	pch_gbe_init_stats(adapter);
+
+	pr_debug("rx_buffer_len : %d  mac.min_frame_size : %d  mac.max_frame_size : %d\n",
+		 (u32) adapter->rx_buffer_len,
+		 hw->mac.min_frame_size, hw->mac.max_frame_size);
+	return 0;
+}
+
+/**
+ * pch_gbe_open - Called when a network interface is made active
+ * @netdev:	Network interface device structure
+ * Returns
+ *	0:		Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_open(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	int err;
+
+	/* allocate transmit descriptors */
+	err = pch_gbe_setup_tx_resources(adapter, adapter->tx_ring);
+	if (err)
+		goto err_setup_tx;
+	/* allocate receive descriptors */
+	err = pch_gbe_setup_rx_resources(adapter, adapter->rx_ring);
+	if (err)
+		goto err_setup_rx;
+	pch_gbe_hal_power_up_phy(hw);
+	err = pch_gbe_up(adapter);
+	if (err)
+		goto err_up;
+	pr_debug("Success End\n");
+	return 0;
+
+err_up:
+	if (!adapter->wake_up_evt)
+		pch_gbe_hal_power_down_phy(hw);
+	pch_gbe_free_rx_resources(adapter, adapter->rx_ring);
+err_setup_rx:
+	pch_gbe_free_tx_resources(adapter, adapter->tx_ring);
+err_setup_tx:
+	pch_gbe_reset(adapter);
+	pr_err("Error End\n");
+	return err;
+}
+
+/**
+ * pch_gbe_stop - Disables a network interface
+ * @netdev:  Network interface device structure
+ * Returns
+ *	0: Successfully
+ */
+static int pch_gbe_stop(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	pch_gbe_down(adapter);
+	if (!adapter->wake_up_evt)
+		pch_gbe_hal_power_down_phy(hw);
+	pch_gbe_free_tx_resources(adapter, adapter->tx_ring);
+	pch_gbe_free_rx_resources(adapter, adapter->rx_ring);
+	return 0;
+}
+
+/**
+ * pch_gbe_xmit_frame - Packet transmitting start
+ * @skb:     Socket buffer structure
+ * @netdev:  Network interface device structure
+ * Returns
+ *	- NETDEV_TX_OK:   Normal end
+ *	- NETDEV_TX_BUSY: Error end
+ */
+static int pch_gbe_xmit_frame(struct sk_buff *skb, struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_tx_ring *tx_ring = adapter->tx_ring;
+	unsigned long flags;
+
+	if (unlikely(skb->len > (adapter->hw.mac.max_frame_size - 4))) {
+		pr_err("Transfer length Error: skb len: %d > max: %d\n",
+		       skb->len, adapter->hw.mac.max_frame_size);
+		dev_kfree_skb_any(skb);
+		adapter->stats.tx_length_errors++;
+		return NETDEV_TX_OK;
+	}
+	if (!spin_trylock_irqsave(&tx_ring->tx_lock, flags)) {
+		/* Collision - tell upper layer to requeue */
+		return NETDEV_TX_LOCKED;
+	}
+	if (unlikely(!PCH_GBE_DESC_UNUSED(tx_ring))) {
+		netif_stop_queue(netdev);
+		spin_unlock_irqrestore(&tx_ring->tx_lock, flags);
+		pr_debug("Return : BUSY  next_to use : 0x%08x  next_to clean : 0x%08x\n",
+			 tx_ring->next_to_use, tx_ring->next_to_clean);
+		return NETDEV_TX_BUSY;
+	}
+	spin_unlock_irqrestore(&tx_ring->tx_lock, flags);
+
+	/* CRC,ITAG no support */
+	pch_gbe_tx_queue(adapter, tx_ring, skb);
+	return NETDEV_TX_OK;
+}
+
+/**
+ * pch_gbe_get_stats - Get System Network Statistics
+ * @netdev:  Network interface device structure
+ * Returns:  The current stats
+ */
+static struct net_device_stats *pch_gbe_get_stats(struct net_device *netdev)
+{
+	/* only return the current stats */
+	return &netdev->stats;
+}
+
+/**
+ * pch_gbe_set_multi - Multicast and Promiscuous mode set
+ * @netdev:   Network interface device structure
+ */
+static void pch_gbe_set_multi(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	struct netdev_hw_addr *ha;
+	u8 *mta_list;
+	u32 rctl;
+	int i;
+	int mc_count;
+
+	pr_debug("netdev->flags : 0x%08x\n", netdev->flags);
+
+	/* Check for Promiscuous and All Multicast modes */
+	rctl = ioread32(&hw->reg->RX_MODE);
+	mc_count = netdev_mc_count(netdev);
+	if ((netdev->flags & IFF_PROMISC)) {
+		rctl &= ~PCH_GBE_ADD_FIL_EN;
+		rctl &= ~PCH_GBE_MLT_FIL_EN;
+	} else if ((netdev->flags & IFF_ALLMULTI)) {
+		/* all the multicasting receive permissions */
+		rctl |= PCH_GBE_ADD_FIL_EN;
+		rctl &= ~PCH_GBE_MLT_FIL_EN;
+	} else {
+		if (mc_count >= PCH_GBE_MAR_ENTRIES) {
+			/* all the multicasting receive permissions */
+			rctl |= PCH_GBE_ADD_FIL_EN;
+			rctl &= ~PCH_GBE_MLT_FIL_EN;
+		} else {
+			rctl |= (PCH_GBE_ADD_FIL_EN | PCH_GBE_MLT_FIL_EN);
+		}
+	}
+	iowrite32(rctl, &hw->reg->RX_MODE);
+
+	if (mc_count >= PCH_GBE_MAR_ENTRIES)
+		return;
+	mta_list = kmalloc(mc_count * ETH_ALEN, GFP_ATOMIC);
+	if (!mta_list)
+		return;
+
+	/* The shared function expects a packed array of only addresses. */
+	i = 0;
+	netdev_for_each_mc_addr(ha, netdev) {
+		if (i == mc_count)
+			break;
+		memcpy(mta_list + (i++ * ETH_ALEN), &ha->addr, ETH_ALEN);
+	}
+	pch_gbe_mac_mc_addr_list_update(hw, mta_list, i, 1,
+					PCH_GBE_MAR_ENTRIES);
+	kfree(mta_list);
+
+	pr_debug("RX_MODE reg(check bit31,30 ADD,MLT) : 0x%08x  netdev->mc_count : 0x%08x\n",
+		 ioread32(&hw->reg->RX_MODE), mc_count);
+}
+
+/**
+ * pch_gbe_set_mac - Change the Ethernet Address of the NIC
+ * @netdev: Network interface device structure
+ * @addr:   Pointer to an address structure
+ * Returns
+ *	0:		Successfully
+ *	-EADDRNOTAVAIL:	Failed
+ */
+static int pch_gbe_set_mac(struct net_device *netdev, void *addr)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct sockaddr *skaddr = addr;
+	int ret_val;
+
+	if (!is_valid_ether_addr(skaddr->sa_data)) {
+		ret_val = -EADDRNOTAVAIL;
+	} else {
+		memcpy(netdev->dev_addr, skaddr->sa_data, netdev->addr_len);
+		memcpy(adapter->hw.mac.addr, skaddr->sa_data, netdev->addr_len);
+		pch_gbe_mac_mar_set(&adapter->hw, adapter->hw.mac.addr, 0);
+		ret_val = 0;
+	}
+	pr_debug("ret_val : 0x%08x\n", ret_val);
+	pr_debug("dev_addr : %pM\n", netdev->dev_addr);
+	pr_debug("mac_addr : %pM\n", adapter->hw.mac.addr);
+	pr_debug("MAC_ADR1AB reg : 0x%08x 0x%08x\n",
+		 ioread32(&adapter->hw.reg->mac_adr[0].high),
+		 ioread32(&adapter->hw.reg->mac_adr[0].low));
+	return ret_val;
+}
+
+/**
+ * pch_gbe_change_mtu - Change the Maximum Transfer Unit
+ * @netdev:   Network interface device structure
+ * @new_mtu:  New value for maximum frame size
+ * Returns
+ *	0:		Successfully
+ *	-EINVAL:	Failed
+ */
+static int pch_gbe_change_mtu(struct net_device *netdev, int new_mtu)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	int max_frame;
+
+	max_frame = new_mtu + ETH_HLEN + ETH_FCS_LEN;
+	if ((max_frame < ETH_ZLEN + ETH_FCS_LEN) ||
+		(max_frame > PCH_GBE_MAX_JUMBO_FRAME_SIZE)) {
+		pr_err("Invalid MTU setting\n");
+		return -EINVAL;
+	}
+	if (max_frame <= PCH_GBE_FRAME_SIZE_2048)
+		adapter->rx_buffer_len = PCH_GBE_FRAME_SIZE_2048;
+	else if (max_frame <= PCH_GBE_FRAME_SIZE_4096)
+		adapter->rx_buffer_len = PCH_GBE_FRAME_SIZE_4096;
+	else if (max_frame <= PCH_GBE_FRAME_SIZE_8192)
+		adapter->rx_buffer_len = PCH_GBE_FRAME_SIZE_8192;
+	else
+		adapter->rx_buffer_len = PCH_GBE_MAX_JUMBO_FRAME_SIZE;
+	netdev->mtu = new_mtu;
+	adapter->hw.mac.max_frame_size = max_frame;
+
+	if (netif_running(netdev))
+		pch_gbe_reinit_locked(adapter);
+	else
+		pch_gbe_reset(adapter);
+
+	pr_debug("max_frame : %d  rx_buffer_len : %d  mtu : %d  max_frame_size : %d\n",
+		 max_frame, (u32) adapter->rx_buffer_len, netdev->mtu,
+		 adapter->hw.mac.max_frame_size);
+	return 0;
+}
+
+/**
+ * pch_gbe_ioctl - Controls register through a MII interface
+ * @netdev:   Network interface device structure
+ * @ifr:      Pointer to ifr structure
+ * @cmd:      Control command
+ * Returns
+ *	0:	Successfully
+ *	Negative value:	Failed
+ */
+static int pch_gbe_ioctl(struct net_device *netdev, struct ifreq *ifr, int cmd)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	pr_debug("cmd : 0x%04x\n", cmd);
+
+	return generic_mii_ioctl(&adapter->mii, if_mii(ifr), cmd, NULL);
+}
+
+/**
+ * pch_gbe_tx_timeout - Respond to a Tx Hang
+ * @netdev:   Network interface device structure
+ */
+static void pch_gbe_tx_timeout(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	/* Do the reset outside of interrupt context */
+	adapter->stats.tx_timeout_count++;
+	schedule_work(&adapter->reset_task);
+}
+
+/**
+ * pch_gbe_napi_poll - NAPI receive and transfer polling callback
+ * @napi:    Pointer of polling device struct
+ * @budget:  The maximum number of a packet
+ * Returns
+ *	false:  Exit the polling mode
+ *	true:   Continue the polling mode
+ */
+static int pch_gbe_napi_poll(struct napi_struct *napi, int budget)
+{
+	struct pch_gbe_adapter *adapter =
+	    container_of(napi, struct pch_gbe_adapter, napi);
+	struct net_device *netdev = adapter->netdev;
+	int work_done = 0;
+	bool poll_end_flag = false;
+	bool cleaned = false;
+
+	pr_debug("budget : %d\n", budget);
+
+	/* Keep link state information with original netdev */
+	if (!netif_carrier_ok(netdev)) {
+		poll_end_flag = true;
+	} else {
+		cleaned = pch_gbe_clean_tx(adapter, adapter->tx_ring);
+		pch_gbe_clean_rx(adapter, adapter->rx_ring, &work_done, budget);
+
+		if (cleaned)
+			work_done = budget;
+		/* If no Tx and not enough Rx work done,
+		 * exit the polling mode
+		 */
+		if ((work_done < budget) || !netif_running(netdev))
+			poll_end_flag = true;
+	}
+
+	if (poll_end_flag) {
+		napi_complete(napi);
+		pch_gbe_irq_enable(adapter);
+	}
+
+	pr_debug("poll_end_flag : %d  work_done : %d  budget : %d\n",
+		 poll_end_flag, work_done, budget);
+
+	return work_done;
+}
+
+#ifdef CONFIG_NET_POLL_CONTROLLER
+/**
+ * pch_gbe_netpoll - Used by things like netconsole to send skbs
+ * @netdev:  Network interface device structure
+ */
+static void pch_gbe_netpoll(struct net_device *netdev)
+{
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	disable_irq(adapter->pdev->irq);
+	pch_gbe_intr(adapter->pdev->irq, netdev);
+	enable_irq(adapter->pdev->irq);
+}
+#endif
+
+static const struct net_device_ops pch_gbe_netdev_ops = {
+	.ndo_open = pch_gbe_open,
+	.ndo_stop = pch_gbe_stop,
+	.ndo_start_xmit = pch_gbe_xmit_frame,
+	.ndo_get_stats = pch_gbe_get_stats,
+	.ndo_set_mac_address = pch_gbe_set_mac,
+	.ndo_tx_timeout = pch_gbe_tx_timeout,
+	.ndo_change_mtu = pch_gbe_change_mtu,
+	.ndo_do_ioctl = pch_gbe_ioctl,
+	.ndo_set_multicast_list = &pch_gbe_set_multi,
+#ifdef CONFIG_NET_POLL_CONTROLLER
+	.ndo_poll_controller = pch_gbe_netpoll,
+#endif
+};
+
+static pci_ers_result_t pch_gbe_io_error_detected(struct pci_dev *pdev,
+						pci_channel_state_t state)
+{
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	netif_device_detach(netdev);
+	if (netif_running(netdev))
+		pch_gbe_down(adapter);
+	pci_disable_device(pdev);
+	/* Request a slot slot reset. */
+	return PCI_ERS_RESULT_NEED_RESET;
+}
+
+static pci_ers_result_t pch_gbe_io_slot_reset(struct pci_dev *pdev)
+{
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	if (pci_enable_device(pdev)) {
+		pr_err("Cannot re-enable PCI device after reset\n");
+		return PCI_ERS_RESULT_DISCONNECT;
+	}
+	pci_set_master(pdev);
+	pci_enable_wake(pdev, PCI_D0, 0);
+	pch_gbe_hal_power_up_phy(hw);
+	pch_gbe_reset(adapter);
+	/* Clear wake up status */
+	pch_gbe_mac_set_wol_event(hw, 0);
+
+	return PCI_ERS_RESULT_RECOVERED;
+}
+
+static void pch_gbe_io_resume(struct pci_dev *pdev)
+{
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	if (netif_running(netdev)) {
+		if (pch_gbe_up(adapter)) {
+			pr_debug("can't bring device back up after reset\n");
+			return;
+		}
+	}
+	netif_device_attach(netdev);
+}
+
+static int __pch_gbe_suspend(struct pci_dev *pdev)
+{
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 wufc = adapter->wake_up_evt;
+	int retval = 0;
+
+	netif_device_detach(netdev);
+	if (netif_running(netdev))
+		pch_gbe_down(adapter);
+	if (wufc) {
+		pch_gbe_set_multi(netdev);
+		pch_gbe_setup_rctl(adapter);
+		pch_gbe_configure_rx(adapter);
+		pch_gbe_set_rgmii_ctrl(adapter, hw->mac.link_speed,
+					hw->mac.link_duplex);
+		pch_gbe_set_mode(adapter, hw->mac.link_speed,
+					hw->mac.link_duplex);
+		pch_gbe_mac_set_wol_event(hw, wufc);
+		pci_disable_device(pdev);
+	} else {
+		pch_gbe_hal_power_down_phy(hw);
+		pch_gbe_mac_set_wol_event(hw, wufc);
+		pci_disable_device(pdev);
+	}
+	return retval;
+}
+
+#ifdef CONFIG_PM
+static int pch_gbe_suspend(struct device *device)
+{
+	struct pci_dev *pdev = to_pci_dev(device);
+
+	return __pch_gbe_suspend(pdev);
+}
+
+static int pch_gbe_resume(struct device *device)
+{
+	struct pci_dev *pdev = to_pci_dev(device);
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+	struct pch_gbe_hw *hw = &adapter->hw;
+	u32 err;
+
+	err = pci_enable_device(pdev);
+	if (err) {
+		pr_err("Cannot enable PCI device from suspend\n");
+		return err;
+	}
+	pci_set_master(pdev);
+	pch_gbe_hal_power_up_phy(hw);
+	pch_gbe_reset(adapter);
+	/* Clear wake on lan control and status */
+	pch_gbe_mac_set_wol_event(hw, 0);
+
+	if (netif_running(netdev))
+		pch_gbe_up(adapter);
+	netif_device_attach(netdev);
+
+	return 0;
+}
+#endif /* CONFIG_PM */
+
+static void pch_gbe_shutdown(struct pci_dev *pdev)
+{
+	__pch_gbe_suspend(pdev);
+	if (system_state == SYSTEM_POWER_OFF) {
+		pci_wake_from_d3(pdev, true);
+		pci_set_power_state(pdev, PCI_D3hot);
+	}
+}
+
+static void pch_gbe_remove(struct pci_dev *pdev)
+{
+	struct net_device *netdev = pci_get_drvdata(pdev);
+	struct pch_gbe_adapter *adapter = netdev_priv(netdev);
+
+	cancel_work_sync(&adapter->reset_task);
+	unregister_netdev(netdev);
+
+	pch_gbe_hal_phy_hw_reset(&adapter->hw);
+
+	kfree(adapter->tx_ring);
+	kfree(adapter->rx_ring);
+
+	iounmap(adapter->hw.reg);
+	pci_release_regions(pdev);
+	free_netdev(netdev);
+	pci_disable_device(pdev);
+}
+
+static int pch_gbe_probe(struct pci_dev *pdev,
+			  const struct pci_device_id *pci_id)
+{
+	struct net_device *netdev;
+	struct pch_gbe_adapter *adapter;
+	int ret;
+	int i;
+	ret = pci_enable_device_mem(pdev);
+	if (ret)
+		return ret;
+
+	if (pci_set_dma_mask(pdev, DMA_BIT_MASK(64))
+		|| pci_set_consistent_dma_mask(pdev, DMA_BIT_MASK(64))) {
+		ret = pci_set_dma_mask(pdev, DMA_BIT_MASK(32));
+		if (ret) {
+			ret = pci_set_consistent_dma_mask(pdev,
+							  DMA_BIT_MASK(32));
+			if (ret) {
+				dev_err(&pdev->dev, "ERR: No usable DMA "
+					"configuration, aborting\n");
+				goto err_disable_device;
+			}
+		}
+	}
+
+	ret = pci_request_regions(pdev, KBUILD_MODNAME);
+	if (ret) {
+		dev_err(&pdev->dev,
+			"ERR: Can't reserve PCI I/O and memory resources\n");
+		goto err_disable_device;
+	}
+	pci_set_master(pdev);
+
+	netdev = alloc_etherdev((int)sizeof(struct pch_gbe_adapter));
+	if (!netdev) {
+		ret = -ENOMEM;
+		dev_err(&pdev->dev,
+			"ERR: Can't allocate and set up an Ethernet device\n");
+		goto err_release_pci;
+	}
+	SET_NETDEV_DEV(netdev, &pdev->dev);
+
+	pci_set_drvdata(pdev, netdev);
+	adapter = netdev_priv(netdev);
+	adapter->netdev = netdev;
+	adapter->pdev = pdev;
+	adapter->hw.back = adapter;
+	adapter->hw.reg = pci_iomap(pdev, PCH_GBE_PCI_BAR, 0);
+	if (!adapter->hw.reg) {
+		ret = -EIO;
+		dev_err(&pdev->dev, "Can't ioremap\n");
+		goto err_free_netdev;
+	}
+
+	/* netdev->netdev_ops = &pch_gbe_netdev_ops; */
+	netdev->open			= &pch_gbe_open;
+	netdev->stop			= &pch_gbe_stop;
+	netdev->hard_start_xmit		= &pch_gbe_xmit_frame;
+	netdev->get_stats		= &pch_gbe_get_stats;
+	netdev->set_multicast_list	= &pch_gbe_set_multi;
+	netdev->set_mac_address		= &pch_gbe_set_mac;
+	netdev->change_mtu		= &pch_gbe_change_mtu;
+	netdev->do_ioctl		= &pch_gbe_ioctl;
+	netdev->tx_timeout		= &pch_gbe_tx_timeout;
+	netdev->watchdog_timeo		= 5 * HZ;
+	netdev->weight			= 64;
+
+	netdev->watchdog_timeo = PCH_GBE_WATCHDOG_PERIOD;
+
+	/* WN mod: commented out the next two lines
+	netif_napi_add(netdev, &adapter->napi,
+		pch_gbe_napi_poll, PCH_GBE_RX_WEIGHT); */
+	netdev->features = NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM | NETIF_F_GRO;
+	pch_gbe_set_ethtool_ops(netdev);
+
+	pch_gbe_mac_load_mac_addr(&adapter->hw);
+	pch_gbe_mac_reset_hw(&adapter->hw);
+
+	/* setup the private structure */
+	ret = pch_gbe_sw_init(adapter);
+	if (ret)
+		goto err_iounmap;
+
+	/* Initialize PHY */
+	ret = pch_gbe_init_phy(adapter);
+	if (ret) {
+		dev_err(&pdev->dev, "PHY initialize error\n");
+		goto err_free_adapter;
+	}
+	pch_gbe_hal_get_bus_info(&adapter->hw);
+
+	/* Read the MAC address. and store to the private data */
+	ret = pch_gbe_hal_read_mac_addr(&adapter->hw);
+	if (ret) {
+		dev_err(&pdev->dev, "MAC address Read Error\n");
+		goto err_free_adapter;
+	}
+
+	memcpy(netdev->dev_addr, adapter->hw.mac.addr, netdev->addr_len);
+	if (!is_valid_ether_addr(netdev->dev_addr)) {
+		dev_err(&pdev->dev, "Invalid MAC Address\n");
+		ret = -EIO;
+		goto err_free_adapter;
+	}
+	setup_timer(&adapter->watchdog_timer, pch_gbe_watchdog,
+		    (unsigned long)adapter);
+
+	//INIT_WORK(&adapter->reset_task, pch_gbe_reset_task);
+	INIT_WORK(&adapter->reset_task, pch_gbe_reset_task,netdev);
+
+	pch_gbe_check_options(adapter);
+
+	if (adapter->tx_csum)
+		netdev->features |= NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM;
+	else
+		netdev->features &= ~(NETIF_F_IP_CSUM | NETIF_F_IPV6_CSUM);
+
+	/* initialize the wol settings based on the eeprom settings */
+	adapter->wake_up_evt = PCH_GBE_WL_INIT_SETTING;
+	dev_info(&pdev->dev, "MAC address : %pM\n", netdev->dev_addr);
+
+	/* reset the hardware with the new settings */
+	pch_gbe_reset(adapter);
+
+	ret = register_netdev(netdev);
+	if (ret)
+		goto err_free_adapter;
+	/* tell the stack to leave us alone until pch_gbe_open() is called */
+	netif_carrier_off(netdev);
+	netif_stop_queue(netdev);
+
+	dev_dbg(&pdev->dev, "OKIsemi(R) PCH Network Connection\n");
+
+	device_set_wakeup_enable(&pdev->dev, 1);
+	return 0;
+
+err_free_adapter:
+	pch_gbe_hal_phy_hw_reset(&adapter->hw);
+	kfree(adapter->tx_ring);
+	kfree(adapter->rx_ring);
+err_iounmap:
+	iounmap(adapter->hw.reg);
+err_free_netdev:
+	free_netdev(netdev);
+err_release_pci:
+	pci_release_regions(pdev);
+err_disable_device:
+	pci_disable_device(pdev);
+	return ret;
+}
+
+static DEFINE_PCI_DEVICE_TABLE(pch_gbe_pcidev_id) = {
+	{.vendor = PCI_VENDOR_ID_INTEL,
+	 .device = PCI_DEVICE_ID_INTEL_IOH1_GBE,
+	 .subvendor = PCI_ANY_ID,
+	 .subdevice = PCI_ANY_ID,
+	 .class = (PCI_CLASS_NETWORK_ETHERNET << 8),
+	 .class_mask = (0xFFFF00)
+	 },
+	/* required last entry */
+	{0}
+};
+
+#ifdef CONFIG_PM
+//static const struct dev_pm_ops pch_gbe_pm_ops = {
+//	.suspend = pch_gbe_suspend,
+//	.resume = pch_gbe_resume,
+//	.freeze = pch_gbe_suspend,
+//	.thaw = pch_gbe_resume,
+//	.poweroff = pch_gbe_suspend,
+//	.restore = pch_gbe_resume,
+//};
+#endif
+
+static struct pci_error_handlers pch_gbe_err_handler = {
+	.error_detected = pch_gbe_io_error_detected,
+	.slot_reset = pch_gbe_io_slot_reset,
+	.resume = pch_gbe_io_resume
+};
+
+static struct pci_driver pch_gbe_pcidev = {
+	.name = KBUILD_MODNAME,
+	.id_table = pch_gbe_pcidev_id,
+	.probe = pch_gbe_probe,
+	.remove = pch_gbe_remove,
+//#ifdef CONFIG_PM
+//	/* Power Management Hooks */
+//	.suspend  = pch_gbe_pm_suspend,
+//	.resume   = pch_gbe_pm_resume,
+//#endif
+//#ifdef CONFIG_PM_OPS
+//	.driver.pm = &pch_gbe_pm_ops,
+//#endif
+	.shutdown = pch_gbe_shutdown,
+	.err_handler = &pch_gbe_err_handler
+};
+
+
+static int __init pch_gbe_init_module(void)
+{
+	int ret;
+
+	ret = pci_register_driver(&pch_gbe_pcidev);
+	if (copybreak != PCH_GBE_COPYBREAK_DEFAULT) {
+		if (copybreak == 0) {
+			pr_info("copybreak disabled\n");
+		} else {
+			pr_info("copybreak enabled for packets <= %u bytes\n",
+				copybreak);
+		}
+	}
+	return ret;
+}
+
+static void __exit pch_gbe_exit_module(void)
+{
+	pci_unregister_driver(&pch_gbe_pcidev);
+}
+
+module_init(pch_gbe_init_module);
+module_exit(pch_gbe_exit_module);
+
+MODULE_DESCRIPTION("EG20T PCH Gigabit ethernet Driver");
+MODULE_AUTHOR("OKI SEMICONDUCTOR, <toshiharu-linux@dsn.okisemi.com>");
+MODULE_LICENSE("GPL");
+MODULE_VERSION(DRV_VERSION);
+MODULE_DEVICE_TABLE(pci, pch_gbe_pcidev_id);
+
+module_param(copybreak, uint, 0644);
+MODULE_PARM_DESC(copybreak,
+	"Maximum size of packet that is copied to a new buffer on receive");
+
+/* pch_gbe_main.c */

--- a/pch_gbe/pch_gbe_param.c
+++ b/pch_gbe/pch_gbe_param.c
@@ -1,0 +1,499 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "pch_gbe.h"
+
+#define OPTION_UNSET   -1
+#define OPTION_DISABLED 0
+#define OPTION_ENABLED  1
+
+/**
+ * TxDescriptors - Transmit Descriptor Count
+ * @Valid Range:   PCH_GBE_MIN_TXD - PCH_GBE_MAX_TXD
+ * @Default Value: PCH_GBE_DEFAULT_TXD
+ */
+static int TxDescriptors = OPTION_UNSET;
+module_param(TxDescriptors, int, 0);
+MODULE_PARM_DESC(TxDescriptors, "Number of transmit descriptors");
+
+/**
+ * RxDescriptors -Receive Descriptor Count
+ * @Valid Range:   PCH_GBE_MIN_RXD - PCH_GBE_MAX_RXD
+ * @Default Value: PCH_GBE_DEFAULT_RXD
+ */
+static int RxDescriptors = OPTION_UNSET;
+module_param(RxDescriptors, int, 0);
+MODULE_PARM_DESC(RxDescriptors, "Number of receive descriptors");
+
+/**
+ * Speed - User Specified Speed Override
+ * @Valid Range: 0, 10, 100, 1000
+ *   - 0:    auto-negotiate at all supported speeds
+ *   - 10:   only link at 10 Mbps
+ *   - 100:  only link at 100 Mbps
+ *   - 1000: only link at 1000 Mbps
+ * @Default Value: 0
+ */
+static int Speed = OPTION_UNSET;
+module_param(Speed, int, 0);
+MODULE_PARM_DESC(Speed, "Speed setting");
+
+/**
+ * Duplex - User Specified Duplex Override
+ * @Valid Range: 0-2
+ *   - 0:  auto-negotiate for duplex
+ *   - 1:  only link at half duplex
+ *   - 2:  only link at full duplex
+ * @Default Value: 0
+ */
+static int Duplex = OPTION_UNSET;
+module_param(Duplex, int, 0);
+MODULE_PARM_DESC(Duplex, "Duplex setting");
+
+#define HALF_DUPLEX 1
+#define FULL_DUPLEX 2
+
+/**
+ * AutoNeg - Auto-negotiation Advertisement Override
+ * @Valid Range: 0x01-0x0F, 0x20-0x2F
+ *
+ *       The AutoNeg value is a bit mask describing which speed and duplex
+ *       combinations should be advertised during auto-negotiation.
+ *       The supported speed and duplex modes are listed below
+ *
+ *       Bit           7     6     5      4      3     2     1      0
+ *       Speed (Mbps)  N/A   N/A   1000   N/A    100   100   10     10
+ *       Duplex                    Full          Full  Half  Full   Half
+ *
+ * @Default Value: 0x2F (copper)
+ */
+static int AutoNeg = OPTION_UNSET;
+module_param(AutoNeg, int, 0);
+MODULE_PARM_DESC(AutoNeg, "Advertised auto-negotiation setting");
+
+#define PHY_ADVERTISE_10_HALF      0x0001
+#define PHY_ADVERTISE_10_FULL      0x0002
+#define PHY_ADVERTISE_100_HALF     0x0004
+#define PHY_ADVERTISE_100_FULL     0x0008
+#define PHY_ADVERTISE_1000_HALF    0x0010 /* Not used, just FYI */
+#define PHY_ADVERTISE_1000_FULL    0x0020
+#define PCH_AUTONEG_ADVERTISE_DEFAULT   0x2F
+
+/**
+ * FlowControl - User Specified Flow Control Override
+ * @Valid Range: 0-3
+ *    - 0:  No Flow Control
+ *    - 1:  Rx only, respond to PAUSE frames but do not generate them
+ *    - 2:  Tx only, generate PAUSE frames but ignore them on receive
+ *    - 3:  Full Flow Control Support
+ * @Default Value: Read flow control settings from the EEPROM
+ */
+static int FlowControl = OPTION_UNSET;
+module_param(FlowControl, int, 0);
+MODULE_PARM_DESC(FlowControl, "Flow Control setting");
+
+/*
+ * XsumRX - Receive Checksum Offload Enable/Disable
+ * @Valid Range: 0, 1
+ *    - 0:  disables all checksum offload
+ *    - 1:  enables receive IP/TCP/UDP checksum offload
+ * @Default Value: PCH_GBE_DEFAULT_RX_CSUM
+ */
+static int XsumRX = OPTION_UNSET;
+module_param(XsumRX, int, 0);
+MODULE_PARM_DESC(XsumRX, "Disable or enable Receive Checksum offload");
+
+#define PCH_GBE_DEFAULT_RX_CSUM             true	/* trueorfalse */
+
+/*
+ * XsumTX - Transmit Checksum Offload Enable/Disable
+ * @Valid Range: 0, 1
+ *    - 0:  disables all checksum offload
+ *    - 1:  enables transmit IP/TCP/UDP checksum offload
+ * @Default Value: PCH_GBE_DEFAULT_TX_CSUM
+ */
+static int XsumTX = OPTION_UNSET;
+module_param(XsumTX, int, 0);
+MODULE_PARM_DESC(XsumTX, "Disable or enable Transmit Checksum offload");
+
+#define PCH_GBE_DEFAULT_TX_CSUM             true	/* trueorfalse */
+
+/**
+ * pch_gbe_option - Force the MAC's flow control settings
+ * @hw:	            Pointer to the HW structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+struct pch_gbe_option {
+	enum { enable_option, range_option, list_option } type;
+	char *name;
+	char *err;
+	int  def;
+	union {
+		struct { /* range_option info */
+			int min;
+			int max;
+		} r;
+		struct { /* list_option info */
+			int nr;
+			const struct pch_gbe_opt_list { int i; char *str; } *p;
+		} l;
+	} arg;
+};
+
+static const struct pch_gbe_opt_list speed_list[] = {
+	{ 0, "" },
+	{ SPEED_10, "" },
+	{ SPEED_100, "" },
+	{ SPEED_1000, "" }
+};
+
+static const struct pch_gbe_opt_list dplx_list[] = {
+	{ 0, "" },
+	{ HALF_DUPLEX, "" },
+	{ FULL_DUPLEX, "" }
+};
+
+static const struct pch_gbe_opt_list an_list[] =
+	#define AA "AutoNeg advertising "
+	{{ 0x01, AA "10/HD" },
+	 { 0x02, AA "10/FD" },
+	 { 0x03, AA "10/FD, 10/HD" },
+	 { 0x04, AA "100/HD" },
+	 { 0x05, AA "100/HD, 10/HD" },
+	 { 0x06, AA "100/HD, 10/FD" },
+	 { 0x07, AA "100/HD, 10/FD, 10/HD" },
+	 { 0x08, AA "100/FD" },
+	 { 0x09, AA "100/FD, 10/HD" },
+	 { 0x0a, AA "100/FD, 10/FD" },
+	 { 0x0b, AA "100/FD, 10/FD, 10/HD" },
+	 { 0x0c, AA "100/FD, 100/HD" },
+	 { 0x0d, AA "100/FD, 100/HD, 10/HD" },
+	 { 0x0e, AA "100/FD, 100/HD, 10/FD" },
+	 { 0x0f, AA "100/FD, 100/HD, 10/FD, 10/HD" },
+	 { 0x20, AA "1000/FD" },
+	 { 0x21, AA "1000/FD, 10/HD" },
+	 { 0x22, AA "1000/FD, 10/FD" },
+	 { 0x23, AA "1000/FD, 10/FD, 10/HD" },
+	 { 0x24, AA "1000/FD, 100/HD" },
+	 { 0x25, AA "1000/FD, 100/HD, 10/HD" },
+	 { 0x26, AA "1000/FD, 100/HD, 10/FD" },
+	 { 0x27, AA "1000/FD, 100/HD, 10/FD, 10/HD" },
+	 { 0x28, AA "1000/FD, 100/FD" },
+	 { 0x29, AA "1000/FD, 100/FD, 10/HD" },
+	 { 0x2a, AA "1000/FD, 100/FD, 10/FD" },
+	 { 0x2b, AA "1000/FD, 100/FD, 10/FD, 10/HD" },
+	 { 0x2c, AA "1000/FD, 100/FD, 100/HD" },
+	 { 0x2d, AA "1000/FD, 100/FD, 100/HD, 10/HD" },
+	 { 0x2e, AA "1000/FD, 100/FD, 100/HD, 10/FD" },
+	 { 0x2f, AA "1000/FD, 100/FD, 100/HD, 10/FD, 10/HD" }
+};
+
+static const struct pch_gbe_opt_list fc_list[] = {
+	{ PCH_GBE_FC_NONE, "Flow Control Disabled" },
+	{ PCH_GBE_FC_RX_PAUSE, "Flow Control Receive Only" },
+	{ PCH_GBE_FC_TX_PAUSE, "Flow Control Transmit Only" },
+	{ PCH_GBE_FC_FULL, "Flow Control Enabled" }
+};
+
+/**
+ * pch_gbe_validate_option - Validate option
+ * @value:    value
+ * @opt:      option
+ * @adapter:  Board private structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+static int pch_gbe_validate_option(int *value,
+				    const struct pch_gbe_option *opt,
+				    struct pch_gbe_adapter *adapter)
+{
+	if (*value == OPTION_UNSET) {
+		*value = opt->def;
+		return 0;
+	}
+
+	switch (opt->type) {
+	case enable_option:
+		switch (*value) {
+		case OPTION_ENABLED:
+			pr_debug("%s Enabled\n", opt->name);
+			return 0;
+		case OPTION_DISABLED:
+			pr_debug("%s Disabled\n", opt->name);
+			return 0;
+		}
+		break;
+	case range_option:
+		if (*value >= opt->arg.r.min && *value <= opt->arg.r.max) {
+			pr_debug("%s set to %i\n", opt->name, *value);
+			return 0;
+		}
+		break;
+	case list_option: {
+		int i;
+		const struct pch_gbe_opt_list *ent;
+
+		for (i = 0; i < opt->arg.l.nr; i++) {
+			ent = &opt->arg.l.p[i];
+			if (*value == ent->i) {
+				if (ent->str[0] != '\0')
+					pr_debug("%s\n", ent->str);
+				return 0;
+			}
+		}
+	}
+		break;
+	default:
+		BUG();
+	}
+
+	pr_debug("Invalid %s value specified (%i) %s\n",
+		 opt->name, *value, opt->err);
+	*value = opt->def;
+	return -1;
+}
+
+/**
+ * pch_gbe_check_copper_options - Range Checking for Link Options, Copper Version
+ * @adapter:  Board private structure
+ */
+static void pch_gbe_check_copper_options(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+	int speed, dplx;
+
+	{ /* Speed */
+		static const struct pch_gbe_option opt = {
+			.type = list_option,
+			.name = "Speed",
+			.err  = "parameter ignored",
+			.def  = 0,
+			.arg  = { .l = { .nr = (int)ARRAY_SIZE(speed_list),
+					 .p = speed_list } }
+		};
+		speed = Speed;
+		pch_gbe_validate_option(&speed, &opt, adapter);
+	}
+	{ /* Duplex */
+		static const struct pch_gbe_option opt = {
+			.type = list_option,
+			.name = "Duplex",
+			.err  = "parameter ignored",
+			.def  = 0,
+			.arg  = { .l = { .nr = (int)ARRAY_SIZE(dplx_list),
+					 .p = dplx_list } }
+		};
+		dplx = Duplex;
+		pch_gbe_validate_option(&dplx, &opt, adapter);
+	}
+
+	{ /* Autoneg */
+		static const struct pch_gbe_option opt = {
+			.type = list_option,
+			.name = "AutoNeg",
+			.err  = "parameter ignored",
+			.def  = PCH_AUTONEG_ADVERTISE_DEFAULT,
+			.arg  = { .l = { .nr = (int)ARRAY_SIZE(an_list),
+					 .p = an_list} }
+		};
+		if (speed || dplx) {
+			pr_debug("AutoNeg specified along with Speed or Duplex, AutoNeg parameter ignored\n");
+			hw->phy.autoneg_advertised = opt.def;
+		} else {
+			hw->phy.autoneg_advertised = AutoNeg;
+			pch_gbe_validate_option(
+				(int *)(&hw->phy.autoneg_advertised),
+				&opt, adapter);
+		}
+	}
+
+	switch (speed + dplx) {
+	case 0:
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		if ((speed || dplx))
+			pr_debug("Speed and duplex autonegotiation enabled\n");
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case HALF_DUPLEX:
+		pr_debug("Half Duplex specified without Speed\n");
+		pr_debug("Using Autonegotiation at Half Duplex only\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		hw->phy.autoneg_advertised = PHY_ADVERTISE_10_HALF |
+						PHY_ADVERTISE_100_HALF;
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case FULL_DUPLEX:
+		pr_debug("Full Duplex specified without Speed\n");
+		pr_debug("Using Autonegotiation at Full Duplex only\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		hw->phy.autoneg_advertised = PHY_ADVERTISE_10_FULL |
+						PHY_ADVERTISE_100_FULL |
+						PHY_ADVERTISE_1000_FULL;
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_FULL;
+		break;
+	case SPEED_10:
+		pr_debug("10 Mbps Speed specified without Duplex\n");
+		pr_debug("Using Autonegotiation at 10 Mbps only\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		hw->phy.autoneg_advertised = PHY_ADVERTISE_10_HALF |
+						PHY_ADVERTISE_10_FULL;
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case SPEED_10 + HALF_DUPLEX:
+		pr_debug("Forcing to 10 Mbps Half Duplex\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 0;
+		hw->phy.autoneg_advertised = 0;
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case SPEED_10 + FULL_DUPLEX:
+		pr_debug("Forcing to 10 Mbps Full Duplex\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 0;
+		hw->phy.autoneg_advertised = 0;
+		hw->mac.link_speed = SPEED_10;
+		hw->mac.link_duplex = DUPLEX_FULL;
+		break;
+	case SPEED_100:
+		pr_debug("100 Mbps Speed specified without Duplex\n");
+		pr_debug("Using Autonegotiation at 100 Mbps only\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		hw->phy.autoneg_advertised = PHY_ADVERTISE_100_HALF |
+						PHY_ADVERTISE_100_FULL;
+		hw->mac.link_speed = SPEED_100;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case SPEED_100 + HALF_DUPLEX:
+		pr_debug("Forcing to 100 Mbps Half Duplex\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 0;
+		hw->phy.autoneg_advertised = 0;
+		hw->mac.link_speed = SPEED_100;
+		hw->mac.link_duplex = DUPLEX_HALF;
+		break;
+	case SPEED_100 + FULL_DUPLEX:
+		pr_debug("Forcing to 100 Mbps Full Duplex\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 0;
+		hw->phy.autoneg_advertised = 0;
+		hw->mac.link_speed = SPEED_100;
+		hw->mac.link_duplex = DUPLEX_FULL;
+		break;
+	case SPEED_1000:
+		pr_debug("1000 Mbps Speed specified without Duplex\n");
+		goto full_duplex_only;
+	case SPEED_1000 + HALF_DUPLEX:
+		pr_debug("Half Duplex is not supported at 1000 Mbps\n");
+		/* fall through */
+	case SPEED_1000 + FULL_DUPLEX:
+full_duplex_only:
+		pr_debug("Using Autonegotiation at 1000 Mbps Full Duplex only\n");
+		hw->mac.autoneg = hw->mac.fc_autoneg = 1;
+		hw->phy.autoneg_advertised = PHY_ADVERTISE_1000_FULL;
+		hw->mac.link_speed = SPEED_1000;
+		hw->mac.link_duplex = DUPLEX_FULL;
+		break;
+	default:
+		BUG();
+	}
+}
+
+/**
+ * pch_gbe_check_options - Range Checking for Command Line Parameters
+ * @adapter:  Board private structure
+ */
+void pch_gbe_check_options(struct pch_gbe_adapter *adapter)
+{
+	struct pch_gbe_hw *hw = &adapter->hw;
+
+	{ /* Transmit Descriptor Count */
+		static const struct pch_gbe_option opt = {
+			.type = range_option,
+			.name = "Transmit Descriptors",
+			.err  = "using default of "
+				__MODULE_STRING(PCH_GBE_DEFAULT_TXD),
+			.def  = PCH_GBE_DEFAULT_TXD,
+			.arg  = { .r = { .min = PCH_GBE_MIN_TXD,
+					 .max = PCH_GBE_MAX_TXD } }
+		};
+		struct pch_gbe_tx_ring *tx_ring = adapter->tx_ring;
+		tx_ring->count = TxDescriptors;
+		pch_gbe_validate_option(&tx_ring->count, &opt, adapter);
+		tx_ring->count = roundup(tx_ring->count,
+					PCH_GBE_TX_DESC_MULTIPLE);
+	}
+	{ /* Receive Descriptor Count */
+		static const struct pch_gbe_option opt = {
+			.type = range_option,
+			.name = "Receive Descriptors",
+			.err  = "using default of "
+				__MODULE_STRING(PCH_GBE_DEFAULT_RXD),
+			.def  = PCH_GBE_DEFAULT_RXD,
+			.arg  = { .r = { .min = PCH_GBE_MIN_RXD,
+					 .max = PCH_GBE_MAX_RXD } }
+		};
+		struct pch_gbe_rx_ring *rx_ring = adapter->rx_ring;
+		rx_ring->count = RxDescriptors;
+		pch_gbe_validate_option(&rx_ring->count, &opt, adapter);
+		rx_ring->count = roundup(rx_ring->count,
+				PCH_GBE_RX_DESC_MULTIPLE);
+	}
+	{ /* Checksum Offload Enable/Disable */
+		static const struct pch_gbe_option opt = {
+			.type = enable_option,
+			.name = "Checksum Offload",
+			.err  = "defaulting to Enabled",
+			.def  = PCH_GBE_DEFAULT_RX_CSUM
+		};
+		adapter->rx_csum = XsumRX;
+		pch_gbe_validate_option((int *)(&adapter->rx_csum),
+					&opt, adapter);
+	}
+	{ /* Checksum Offload Enable/Disable */
+		static const struct pch_gbe_option opt = {
+			.type = enable_option,
+			.name = "Checksum Offload",
+			.err  = "defaulting to Enabled",
+			.def  = PCH_GBE_DEFAULT_TX_CSUM
+		};
+		adapter->tx_csum = XsumTX;
+		pch_gbe_validate_option((int *)(&adapter->tx_csum),
+						&opt, adapter);
+	}
+	{ /* Flow Control */
+		static const struct pch_gbe_option opt = {
+			.type = list_option,
+			.name = "Flow Control",
+			.err  = "reading default settings from EEPROM",
+			.def  = PCH_GBE_FC_DEFAULT,
+			.arg  = { .l = { .nr = (int)ARRAY_SIZE(fc_list),
+					 .p = fc_list } }
+		};
+		hw->mac.fc = FlowControl;
+		pch_gbe_validate_option((int *)(&hw->mac.fc),
+						&opt, adapter);
+	}
+
+	pch_gbe_check_copper_options(adapter);
+}

--- a/pch_gbe/pch_gbe_phy.c
+++ b/pch_gbe/pch_gbe_phy.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "pch_gbe.h"
+#include "pch_gbe_phy.h"
+
+#define PHY_MAX_REG_ADDRESS   0x1F	/* 5 bit address bus (0-0x1F) */
+
+/* PHY 1000 MII Register/Bit Definitions */
+/* PHY Registers defined by IEEE */
+#define PHY_CONTROL           0x00  /* Control Register */
+#define PHY_STATUS            0x01  /* Status Regiser */
+#define PHY_ID1               0x02  /* Phy Id Register (word 1) */
+#define PHY_ID2               0x03  /* Phy Id Register (word 2) */
+#define PHY_AUTONEG_ADV       0x04  /* Autoneg Advertisement */
+#define PHY_LP_ABILITY        0x05  /* Link Partner Ability (Base Page) */
+#define PHY_AUTONEG_EXP       0x06  /* Autoneg Expansion Register */
+#define PHY_NEXT_PAGE_TX      0x07  /* Next Page TX */
+#define PHY_LP_NEXT_PAGE      0x08  /* Link Partner Next Page */
+#define PHY_1000T_CTRL        0x09  /* 1000Base-T Control Register */
+#define PHY_1000T_STATUS      0x0A  /* 1000Base-T Status Register */
+#define PHY_EXT_STATUS        0x0F  /* Extended Status Register */
+#define PHY_PHYSP_CONTROL     0x10  /* PHY Specific Control Register */
+#define PHY_EXT_PHYSP_CONTROL 0x14  /* Extended PHY Specific Control Register */
+#define PHY_LED_CONTROL       0x18  /* LED Control Register */
+#define PHY_EXT_PHYSP_STATUS  0x1B  /* Extended PHY Specific Status Register */
+
+/* PHY Control Register */
+#define MII_CR_SPEED_SELECT_MSB 0x0040	/* bits 6,13: 10=1000, 01=100, 00=10 */
+#define MII_CR_COLL_TEST_ENABLE 0x0080	/* Collision test enable */
+#define MII_CR_FULL_DUPLEX      0x0100	/* FDX =1, half duplex =0 */
+#define MII_CR_RESTART_AUTO_NEG 0x0200	/* Restart auto negotiation */
+#define MII_CR_ISOLATE          0x0400	/* Isolate PHY from MII */
+#define MII_CR_POWER_DOWN       0x0800	/* Power down */
+#define MII_CR_AUTO_NEG_EN      0x1000	/* Auto Neg Enable */
+#define MII_CR_SPEED_SELECT_LSB 0x2000	/* bits 6,13: 10=1000, 01=100, 00=10 */
+#define MII_CR_LOOPBACK         0x4000	/* 0 = normal, 1 = loopback */
+#define MII_CR_RESET            0x8000	/* 0 = normal, 1 = PHY reset */
+#define MII_CR_SPEED_1000       0x0040
+#define MII_CR_SPEED_100        0x2000
+#define MII_CR_SPEED_10         0x0000
+
+/* PHY Status Register */
+#define MII_SR_EXTENDED_CAPS     0x0001	/* Extended register capabilities */
+#define MII_SR_JABBER_DETECT     0x0002	/* Jabber Detected */
+#define MII_SR_LINK_STATUS       0x0004	/* Link Status 1 = link */
+#define MII_SR_AUTONEG_CAPS      0x0008	/* Auto Neg Capable */
+#define MII_SR_REMOTE_FAULT      0x0010	/* Remote Fault Detect */
+#define MII_SR_AUTONEG_COMPLETE  0x0020	/* Auto Neg Complete */
+#define MII_SR_PREAMBLE_SUPPRESS 0x0040	/* Preamble may be suppressed */
+#define MII_SR_EXTENDED_STATUS   0x0100	/* Ext. status info in Reg 0x0F */
+#define MII_SR_100T2_HD_CAPS     0x0200	/* 100T2 Half Duplex Capable */
+#define MII_SR_100T2_FD_CAPS     0x0400	/* 100T2 Full Duplex Capable */
+#define MII_SR_10T_HD_CAPS       0x0800	/* 10T   Half Duplex Capable */
+#define MII_SR_10T_FD_CAPS       0x1000	/* 10T   Full Duplex Capable */
+#define MII_SR_100X_HD_CAPS      0x2000	/* 100X  Half Duplex Capable */
+#define MII_SR_100X_FD_CAPS      0x4000	/* 100X  Full Duplex Capable */
+#define MII_SR_100T4_CAPS        0x8000	/* 100T4 Capable */
+
+/* Phy Id Register (word 2) */
+#define PHY_REVISION_MASK        0x000F
+
+/* PHY Specific Control Register */
+#define PHYSP_CTRL_ASSERT_CRS_TX  0x0800
+
+
+/* Default value of PHY register */
+#define PHY_CONTROL_DEFAULT         0x1140 /* Control Register */
+#define PHY_AUTONEG_ADV_DEFAULT     0x01e0 /* Autoneg Advertisement */
+#define PHY_NEXT_PAGE_TX_DEFAULT    0x2001 /* Next Page TX */
+#define PHY_1000T_CTRL_DEFAULT      0x0300 /* 1000Base-T Control Register */
+#define PHY_PHYSP_CONTROL_DEFAULT   0x01EE /* PHY Specific Control Register */
+
+/**
+ * pch_gbe_phy_get_id - Retrieve the PHY ID and revision
+ * @hw:	       Pointer to the HW structure
+ * Returns
+ *	0:			Successful.
+ *	Negative value:		Failed.
+ */
+s32 pch_gbe_phy_get_id(struct pch_gbe_hw *hw)
+{
+	struct pch_gbe_phy_info *phy = &hw->phy;
+	s32 ret;
+	u16 phy_id1;
+	u16 phy_id2;
+
+	ret = pch_gbe_phy_read_reg_miic(hw, PHY_ID1, &phy_id1);
+	if (ret)
+		return ret;
+	ret = pch_gbe_phy_read_reg_miic(hw, PHY_ID2, &phy_id2);
+	if (ret)
+		return ret;
+	/*
+	 * PHY_ID1: [bit15-0:ID(21-6)]
+	 * PHY_ID2: [bit15-10:ID(5-0)][bit9-4:Model][bit3-0:revision]
+	 */
+	phy->id = (u32)phy_id1;
+	phy->id = ((phy->id << 6) | ((phy_id2 & 0xFC00) >> 10));
+	phy->revision = (u32) (phy_id2 & 0x000F);
+	pr_debug("phy->id : 0x%08x  phy->revision : 0x%08x\n",
+		 phy->id, phy->revision);
+	return 0;
+}
+
+/**
+ * pch_gbe_phy_read_reg_miic - Read MII control register
+ * @hw:	     Pointer to the HW structure
+ * @offset:  Register offset to be read
+ * @data:    Pointer to the read data
+ * Returns
+ *	0:		Successful.
+ *	-EINVAL:	Invalid argument.
+ */
+s32 pch_gbe_phy_read_reg_miic(struct pch_gbe_hw *hw, u32 offset, u16 *data)
+{
+	struct pch_gbe_phy_info *phy = &hw->phy;
+
+	if (offset > PHY_MAX_REG_ADDRESS) {
+		pr_err("PHY Address %d is out of range\n", offset);
+		return -EINVAL;
+	}
+	*data = pch_gbe_mac_ctrl_miim(hw, phy->addr, PCH_GBE_HAL_MIIM_READ,
+				      offset, (u16)0);
+	return 0;
+}
+
+/**
+ * pch_gbe_phy_write_reg_miic - Write MII control register
+ * @hw:	     Pointer to the HW structure
+ * @offset:  Register offset to be read
+ * @data:    data to write to register at offset
+ * Returns
+ *	0:		Successful.
+ *	-EINVAL:	Invalid argument.
+ */
+s32 pch_gbe_phy_write_reg_miic(struct pch_gbe_hw *hw, u32 offset, u16 data)
+{
+	struct pch_gbe_phy_info *phy = &hw->phy;
+
+	if (offset > PHY_MAX_REG_ADDRESS) {
+		pr_err("PHY Address %d is out of range\n", offset);
+		return -EINVAL;
+	}
+	pch_gbe_mac_ctrl_miim(hw, phy->addr, PCH_GBE_HAL_MIIM_WRITE,
+				 offset, data);
+	return 0;
+}
+
+/**
+ * pch_gbe_phy_sw_reset - PHY software reset
+ * @hw:	            Pointer to the HW structure
+ */
+void pch_gbe_phy_sw_reset(struct pch_gbe_hw *hw)
+{
+	u16 phy_ctrl;
+
+	pch_gbe_phy_read_reg_miic(hw, PHY_CONTROL, &phy_ctrl);
+	phy_ctrl |= MII_CR_RESET;
+	pch_gbe_phy_write_reg_miic(hw, PHY_CONTROL, phy_ctrl);
+	udelay(1);
+}
+
+/**
+ * pch_gbe_phy_hw_reset - PHY hardware reset
+ * @hw:	   Pointer to the HW structure
+ */
+void pch_gbe_phy_hw_reset(struct pch_gbe_hw *hw)
+{
+	pch_gbe_phy_write_reg_miic(hw, PHY_CONTROL, PHY_CONTROL_DEFAULT);
+	pch_gbe_phy_write_reg_miic(hw, PHY_AUTONEG_ADV,
+					PHY_AUTONEG_ADV_DEFAULT);
+	pch_gbe_phy_write_reg_miic(hw, PHY_NEXT_PAGE_TX,
+					PHY_NEXT_PAGE_TX_DEFAULT);
+	pch_gbe_phy_write_reg_miic(hw, PHY_1000T_CTRL, PHY_1000T_CTRL_DEFAULT);
+	pch_gbe_phy_write_reg_miic(hw, PHY_PHYSP_CONTROL,
+					PHY_PHYSP_CONTROL_DEFAULT);
+}
+
+/**
+ * pch_gbe_phy_power_up - restore link in case the phy was powered down
+ * @hw:	   Pointer to the HW structure
+ */
+void pch_gbe_phy_power_up(struct pch_gbe_hw *hw)
+{
+	u16 mii_reg;
+
+	mii_reg = 0;
+	/* Just clear the power down bit to wake the phy back up */
+	/* according to the manual, the phy will retain its
+	 * settings across a power-down/up cycle */
+	pch_gbe_phy_read_reg_miic(hw, PHY_CONTROL, &mii_reg);
+	mii_reg &= ~MII_CR_POWER_DOWN;
+	pch_gbe_phy_write_reg_miic(hw, PHY_CONTROL, mii_reg);
+}
+
+/**
+ * pch_gbe_phy_power_down - Power down PHY
+ * @hw:	   Pointer to the HW structure
+ */
+void pch_gbe_phy_power_down(struct pch_gbe_hw *hw)
+{
+	u16 mii_reg;
+
+	mii_reg = 0;
+	/* Power down the PHY so no link is implied when interface is down *
+	 * The PHY cannot be powered down if any of the following is TRUE *
+	 * (a) WoL is enabled
+	 * (b) AMT is active
+	 */
+	pch_gbe_phy_read_reg_miic(hw, PHY_CONTROL, &mii_reg);
+	mii_reg |= MII_CR_POWER_DOWN;
+	pch_gbe_phy_write_reg_miic(hw, PHY_CONTROL, mii_reg);
+	mdelay(1);
+}
+
+/**
+ * pch_gbe_phy_set_rgmii - RGMII interface setting
+ * @hw:	            Pointer to the HW structure
+ */
+inline void pch_gbe_phy_set_rgmii(struct pch_gbe_hw *hw)
+{
+	pch_gbe_phy_sw_reset(hw);
+}
+
+/**
+ * pch_gbe_phy_init_setting - PHY initial setting
+ * @hw:	            Pointer to the HW structure
+ */
+void pch_gbe_phy_init_setting(struct pch_gbe_hw *hw)
+{
+	struct pch_gbe_adapter *adapter;
+	struct ethtool_cmd     cmd;
+	int ret;
+	u16 mii_reg;
+
+	adapter = container_of(hw, struct pch_gbe_adapter, hw);
+	ret = mii_ethtool_gset(&adapter->mii, &cmd);
+	if (ret)
+		pr_err("Error: mii_ethtool_gset\n");
+
+	cmd.speed = hw->mac.link_speed;
+	cmd.duplex = hw->mac.link_duplex;
+	cmd.advertising = hw->phy.autoneg_advertised;
+	cmd.autoneg = hw->mac.autoneg;
+	pch_gbe_phy_write_reg_miic(hw, MII_BMCR, BMCR_RESET);
+	ret = mii_ethtool_sset(&adapter->mii, &cmd);
+	if (ret)
+		pr_err("Error: mii_ethtool_sset\n");
+
+	pch_gbe_phy_sw_reset(hw);
+
+	pch_gbe_phy_read_reg_miic(hw, PHY_PHYSP_CONTROL, &mii_reg);
+	mii_reg |= PHYSP_CTRL_ASSERT_CRS_TX;
+	pch_gbe_phy_write_reg_miic(hw, PHY_PHYSP_CONTROL, mii_reg);
+
+}

--- a/pch_gbe/pch_gbe_phy.h
+++ b/pch_gbe/pch_gbe_phy.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 1999 - 2010 Intel Corporation.
+ * Copyright (C) 2010 OKI SEMICONDUCTOR Co., LTD.
+ *
+ * This code was derived from the Intel e1000e Linux driver.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307, USA.
+ */
+#ifndef _PCH_GBE_PHY_H_
+#define _PCH_GBE_PHY_H_
+
+#define PCH_GBE_PHY_REGS_LEN		32
+#define	PCH_GBE_PHY_RESET_DELAY_US	10
+#define PCH_GBE_MAC_IFOP_RGMII
+
+s32 pch_gbe_phy_get_id(struct pch_gbe_hw *hw);
+s32 pch_gbe_phy_read_reg_miic(struct pch_gbe_hw *hw, u32 offset, u16 *data);
+s32 pch_gbe_phy_write_reg_miic(struct pch_gbe_hw *hw, u32 offset, u16 data);
+void pch_gbe_phy_sw_reset(struct pch_gbe_hw *hw);
+void pch_gbe_phy_hw_reset(struct pch_gbe_hw *hw);
+void pch_gbe_phy_power_up(struct pch_gbe_hw *hw);
+void pch_gbe_phy_power_down(struct pch_gbe_hw *hw);
+void pch_gbe_phy_set_rgmii(struct pch_gbe_hw *hw);
+void pch_gbe_phy_init_setting(struct pch_gbe_hw *hw);
+
+#endif /* _PCH_GBE_PHY_H_ */


### PR DESCRIPTION
NOTE: This module is not functioning yet !!!

This is a backport attempt for kernel module pch_gbe from kernel 2.6.38
to 2.6.18-238 (RHEL5 kernel). As far as implemented, the module is
being built against 2.6.18-238, but in fact when insmod'ding it, a
kernel panic is the result.
The modified code in this tree is marked with comments "WN mod".

For compilation, additionally the file include/linux/netdevice.h of
the 2.6.18 kernel sources was modified. So before calling make, the
modified netdevice.h in the subdir of this tree should be copied in
place.

Before testing, the module mii has to be loaded, because pch_gbe is
based on it.
When insmod'ding the binary module, the resulting call trace of the
kernel panic looks about like this:

pch_gbe_probe
__driver_attach
pci_device_probe
driver_probe_device
__driver_attach
bus_for_each_dev
driver_attach
bus_add_driver
__pci_register_driver
pch_gbe_init_module
sys_init_module
mii_ethtool_gdet
dput
syscall
