### PR TITLE
Adding BuildRequires: systemd to bumblebee.spec for el7

### DIFF
--- a/bumblebee/el7/bumblebee.spec
+++ b/bumblebee/el7/bumblebee.spec
@@ -12,6 +12,7 @@ BuildRequires: autoconf
 BuildRequires: help2man
 BuildRequires: glib2-devel
 BuildRequires: libX11-devel
+BuildRequires: systemd
 Requires: libbsd 	
 Requires: VirtualGL
 Requires: kmod-nvidia


### PR DESCRIPTION
systemd is needed for 'unitdir' macro.
http://osdir.com/ml/scm-fedora-commits/2013-08/msg21625.html
