### PR TITLE
Add -t option to nvidia-detect for terse output (package name only).

### DIFF
--- a/nvidia-detect/README
+++ b/nvidia-detect/README
@@ -45,6 +45,11 @@ nvidia-detect may be run from within a script and will return the following code
 4: Device supported by the legacy 304.xx NVIDIA driver
 5: Device supported by the legacy 340.xx NVIDIA driver
 
+nvidia-detect may be run with terse output (returns package name only):
+
+$ nvidia-detect
+kmod-nvidia-304xx
+
 For a full list of supported devices, see:
 ftp://download.nvidia.com/XFree86/Linux-x86_64/346.35/README/supportedchips.html
 

--- a/nvidia-detect/nvidia-detect.c
+++ b/nvidia-detect/nvidia-detect.c
@@ -245,12 +245,12 @@ static int nv_lookup_device_id(u_int16_t device_id)
 		}
 	}
 
-	/** Terse Output **/
 	/** Catch NVIDIA devices that aren't supported **/
-	printf("This device does not appear to be supported at present\n");
-	printf("Please report at http://elrepo.org/bugs quoting the output "
-		"from '/sbin/lspci -nn'\n");
-
+	if (!opt_terse) {
+		printf("This device does not appear to be supported at present\n");
+		printf("Please report at http://elrepo.org/bugs quoting the output "
+			"from '/sbin/lspci -nn'\n");
+	}
 	return NVIDIA_NONE;
 }
 
@@ -445,7 +445,7 @@ int main(int argc, char *argv[])
 
 	/* Catch cases where no NVIDIA devices were detected */
 	if (!has_nvidia)
-		if (opt_terse != 1) {
+		if (!opt_terse) {
 			printf("No NVIDIA devices were found.\n");
 		}
 

--- a/nvidia-detect/nvidia-detect.c
+++ b/nvidia-detect/nvidia-detect.c
@@ -87,6 +87,9 @@ static struct pci_dev *dev;
 /* command line options */
 static bool opt_list = 0;
 static bool opt_xorg = 0;
+static bool opt_terse = 0;
+
+static int ret = 0;
 
 static struct option longopts[] = {
 	/* { name  has_arg  *flag  val } */
@@ -107,8 +110,9 @@ static void usage(void)
 	printf("Usage: %s [-lxVh]\n", PROGRAM_NAME);
 	printf("  -l, --list         list all supported NVIDIA devices\n");
 	printf("  -x, --xorg         display xorg compatibility information\n");
-	printf("  -V, --version      display version number and exit\n");
 	printf("  -h, --help         print this help and exit\n\n");
+	printf("  -t, --help         terse output (package name only)\n\n");
+	printf("  -V, --version      display version number and exit\n");
 	printf("Detect NVIDIA graphics cards and determine the correct NVIDIA driver.\n\n");
 	printf("%s will return the following codes:\n\n", PROGRAM_NAME);
 	printf("0: No supported devices found\n");
@@ -189,8 +193,10 @@ static int nv_lookup_device_id(u_int16_t device_id)
 	/** Find devices supported by the current driver **/
 	for (i = 0; i < ARRAY_SIZE(nv_current_pci_ids); i++) {
 		if (device_id == nv_current_pci_ids[i]) {
-			printf("This device requires the current %3.2f NVIDIA "
-				"driver %s\n", NVIDIA_VERSION, KMOD_NVIDIA);
+			if (!opt_terse) {
+				printf("This device requires the current %3.2f NVIDIA "
+					"driver %s\n", NVIDIA_VERSION, KMOD_NVIDIA);
+			}
 			return NVIDIA_CURRENT;
 		}
 	}
@@ -198,8 +204,10 @@ static int nv_lookup_device_id(u_int16_t device_id)
 	/** Find devices supported by the 340xx legacy driver **/
 	for (i = 0; i < ARRAY_SIZE(nv_340xx_pci_ids); i++) {
 		if (device_id == nv_340xx_pci_ids[i]) {
-			printf("This device requires the legacy 340.xx NVIDIA "
-				"driver %s\n", KMOD_NVIDIA_340XX);
+			if (!opt_terse) {
+				printf("This device requires the legacy 340.xx NVIDIA "
+					"driver %s\n", KMOD_NVIDIA_340XX);
+			}
 			return NVIDIA_LEGACY_340XX;
 		}
 	}
@@ -207,8 +215,10 @@ static int nv_lookup_device_id(u_int16_t device_id)
 	/** Find devices supported by the 304xx legacy driver **/
 	for (i = 0; i < ARRAY_SIZE(nv_304xx_pci_ids); i++) {
 		if (device_id == nv_304xx_pci_ids[i]) {
-			printf("This device requires the legacy 304.xx NVIDIA "
-				"driver %s\n", KMOD_NVIDIA_304XX);
+			if (!opt_terse) {
+				printf("This device requires the legacy 304.xx NVIDIA "
+					"driver %s\n", KMOD_NVIDIA_304XX);
+			}
 			return NVIDIA_LEGACY_304XX;
 		}
 	}
@@ -216,8 +226,10 @@ static int nv_lookup_device_id(u_int16_t device_id)
 	/** Find devices supported by the 173xx legacy driver **/
 	for (i = 0; i < ARRAY_SIZE(nv_173xx_pci_ids); i++) {
 		if (device_id == nv_173xx_pci_ids[i]) {
-			printf("This device requires the legacy 173.xx NVIDIA "
-				"driver %s\n", KMOD_NVIDIA_173XX);
+			if (!opt_terse) {
+				printf("This device requires the legacy 173.xx NVIDIA "
+					"driver %s\n", KMOD_NVIDIA_173XX);
+			}
 			return NVIDIA_LEGACY_173XX;
 		}
 	}
@@ -225,12 +237,15 @@ static int nv_lookup_device_id(u_int16_t device_id)
 	/** Find devices supported by the 96xx legacy driver **/
 	for (i = 0; i < ARRAY_SIZE(nv_96xx_pci_ids); i++) {
 		if (device_id == nv_96xx_pci_ids[i]) {
-			printf("This device requires the legacy 96.xx NVIDIA "
-				"driver %s\n", KMOD_NVIDIA_96XX);
+			if (!opt_terse) {
+				printf("This device requires the legacy 96.xx NVIDIA "
+					"driver %s\n", KMOD_NVIDIA_96XX);
+			}
 			return NVIDIA_LEGACY_96XX;
 		}
 	}
 
+	/** Terse Output **/
 	/** Catch NVIDIA devices that aren't supported **/
 	printf("This device does not appear to be supported at present\n");
 	printf("Please report at http://elrepo.org/bugs quoting the output "
@@ -276,6 +291,32 @@ static int get_xorg_abi(void)
 	return version;
 }
 
+static bool terse_output()
+{
+	if (ret == NVIDIA_CURRENT) {
+		printf("%s\n", KMOD_NVIDIA);
+		return 0;
+	}
+	else if (ret == NVIDIA_LEGACY_340XX) {
+		printf("%s\n", KMOD_NVIDIA_340XX);
+		return 0;
+	}
+	else if (ret == NVIDIA_LEGACY_304XX) {
+		printf("%s\n", KMOD_NVIDIA_304XX);
+		return 0;
+	}
+	else if (ret == NVIDIA_LEGACY_173XX) {
+		printf("%s\n", KMOD_NVIDIA_173XX);
+		return 0;
+	}
+	else if (ret == NVIDIA_LEGACY_96XX) {
+		printf("%s\n", KMOD_NVIDIA_96XX);
+		return 0;
+	} else {
+	return 0;
+	}
+}
+
 static bool check_xorg_abi_compat(int driver)
 {
 	int abi = 0;
@@ -305,10 +346,9 @@ int main(int argc, char *argv[])
 	bool has_intel = 0;
 	bool has_nvidia = 0;
 	bool abi_compat = 0;
-	int ret = 0;
 	int c = 0;
 
-	while ((c = getopt_long(argc, argv, "lxVh", longopts, 0)) != EOF)
+	while ((c = getopt_long(argc, argv, "lxVht", longopts, 0)) != EOF)
 		switch (c) {
 		case 'l':
 			opt_list = true;
@@ -322,6 +362,9 @@ int main(int argc, char *argv[])
 		case 'h':
 			usage();
 			exit(0);
+		case 't':
+			opt_terse = true;
+			break;
 		default:
 			usage();
 			exit(0);
@@ -337,7 +380,9 @@ int main(int argc, char *argv[])
 
 	pci_scan_bus(pacc);		/* Scan the bus for devices */
 
-	printf("Probing for supported NVIDIA devices...\n");
+	if (!opt_terse) {
+		printf("Probing for supported NVIDIA devices...\n");
+	}
 
 	/* Iterate over all devices */
 	for (dev=pacc->devices; dev; dev=dev->next) {
@@ -355,13 +400,17 @@ int main(int argc, char *argv[])
 				PCI_LOOKUP_VENDOR | PCI_LOOKUP_DEVICE,
 				dev->vendor_id, dev->device_id);
 
-			printf("[%04x:%04x] %s\n",
-				dev->vendor_id, dev->device_id, name);
+			if (!opt_terse) {
+				printf("[%04x:%04x] %s\n",
+					dev->vendor_id, dev->device_id, name);
+			}
 
 			/* Find NVIDIA device */
 			if (dev->vendor_id == PCI_VENDOR_ID_NVIDIA) {
 				has_nvidia = true;
 				ret = nv_lookup_device_id(dev->device_id);
+
+
 			}
 
 			/* 
@@ -396,10 +445,15 @@ int main(int argc, char *argv[])
 
 	/* Catch cases where no NVIDIA devices were detected */
 	if (!has_nvidia)
-		printf("No NVIDIA devices were found.\n");
+		if (opt_terse != 1) {
+			printf("No NVIDIA devices were found.\n");
+		}
 
 exit:
 	pci_cleanup(pacc);	/* Close everything */
 
+	if (opt_terse) {
+		terse_output();
+	}
 	exit(ret);
 }


### PR DESCRIPTION
This makes it possible to do, for example:

$ yum install $(nvidia-detect)