### PR TITLE
Compatibility fix for 3.10.0-327.22.2.el7 Kernels

### DIFF
--- a/via-rhine-kmod/el7/via-rhine.c
+++ b/via-rhine-kmod/el7/via-rhine.c
@@ -139,6 +139,16 @@ MODULE_PARM_DESC(avoid_D3, "Avoid power state D3 (work-around for broken BIOSes)
 #define MCAM_SIZE	32
 #define VCAM_SIZE	32
 
+/* Compatibiliy fixes for 3.10.0-327.22.2.el7 */
+#if !defined(vlan_tx_tag_get) && defined(skb_vlan_tag_get)
+# define vlan_tx_tag_get skb_vlan_tag_get
+# define vlan_tx_tag_present skb_vlan_tag_present
+#endif
+#if !defined(u64_stats_fetch_begin_bh)
+# define u64_stats_fetch_begin_bh u64_stats_fetch_begin_irq
+# define u64_stats_fetch_retry_bh u64_stats_fetch_retry_irq
+#endif
+
 /*
 		Theory of Operation
 


### PR DESCRIPTION
This allows compilation of the via-rhine module against the newer C7 kernels.

They've backported some changes from later kernels:

http://marc.info/?t=139477131500001&r=1&w=2
