### PR TITLE
Add kernel cmd line option 'plymouth.ignore-udev'

### DIFF
--- a/nvidia-x11-drv/el7/nvidia-x11-drv.spec
+++ b/nvidia-x11-drv/el7/nvidia-x11-drv.spec
@@ -383,7 +383,7 @@ if [ "$1" -eq "1" ]; then # new install
       cp -p %{_sysconfdir}/X11/nvidia-xorg.conf %{_sysconfdir}/X11/xorg.conf &>/dev/null
     # Disable the nouveau driver
     [ -f %{_sysconfdir}/default/grub ] && \
-      %{__perl} -pi -e 's|(GRUB_CMDLINE_LINUX=".*)"|$1 nouveau\.modeset=0 rd\.driver\.blacklist=nouveau"|g' \
+      %{__perl} -pi -e 's|(GRUB_CMDLINE_LINUX=".*)"|$1 nouveau\.modeset=0 rd\.driver\.blacklist=nouveau plymouth\.ignore-udev"|g' \
         %{_sysconfdir}/default/grub
     if [ -x /usr/sbin/grubby ]; then
       # get installed kernels
@@ -394,7 +394,7 @@ if [ "$1" -eq "1" ]; then # new install
           if [[ "$KERNEL" == "$KABI" && -e "$VMLINUZ" ]]; then
             /usr/bin/dracut --add-drivers nvidia -f /boot/initramfs-$KERNEL.img $KERNEL
             /usr/sbin/grubby --update-kernel="$VMLINUZ" \
-              --args='nouveau.modeset=0 rd.driver.blacklist=nouveau' &>/dev/null
+              --args='nouveau.modeset=0 rd.driver.blacklist=nouveau plymouth.ignore-udev' &>/dev/null
           fi
         done
       done


### PR DESCRIPTION
After installing the nvidia drivers, plymouth no longer functions, not even in text mode. Although Plymouth claims to fall back to text mode, it does not do so if it finds a DRM device.

It asks udev for a list of DRM or FB devices, and finds one provided by the 'nvidia' driver. However the nvidia DRM driver doesn't function as other DRM drivers do (i.e. it lacks real KMS or fbdev). At this point it should fall back to the text/console output but plymouth assumes that if it found a DRM device it should have worked, and so doesn't fall back to text/console. This often leads to a blank screen during boot, which is a problem for the systemd/PackageKit offline updates or if plymouth needs to ask for passwords.

This change sets the kernel command line option 'plymouth.ignore-udev' which causes plymouth to not ask udev for a list of DRM or FB devices at all. This means that plymouth starts in text mode and works correctly, even if it is just the fallback text mode. This is much better than having a blank screen during startup.

Existing solutions like setting the GRUB video mode or setting the vga=<mode> flags explicitly are not supported by the NVIDIA driver because they use a framebuffer (vesafb). Although this may appear to work, it can cause issues such as screen corruption. This change adds an option that lets both plymouth and NVIDIA work correctly.