### PR TITLE
Fix the docbooks.xsl issue at build time

### DIFF
--- a/drbd90-utils/el7/drbd90-utils.spec
+++ b/drbd90-utils/el7/drbd90-utils.spec
@@ -14,6 +14,7 @@ BuildRoot:     %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildRequires: flex
 BuildRequires: udev
 BuildRequires: libxslt
+BuildRequires: docbook-style-xsl
 
 Requires: udev
 Requires(post):   systemd-units


### PR DESCRIPTION
drbd-utils needs docbook.xsl stylesheet to build man pages. If it's not in the buildroot, it tries to download it from internet, but fails if the builders don't have internet access (default on CentOS CBS/koji setup) : 
https://cbs.centos.org/koji/getfile?taskID=185155&name=build.log&offset=-4000

Adding docbook-style-xsl as BuildRequires fixe that issue (https://cbs.centos.org/koji/taskinfo?taskID=185165)