### PR TITLE
Update to WireGuard to 1.0.20200401

### DIFF
--- a/wireguard-kmod/el7/wireguard-kmod.spec
+++ b/wireguard-kmod/el7/wireguard-kmod.spec
@@ -5,7 +5,7 @@
 %{!?kversion: %define kversion 3.10.0-1062.el7.%{_target_cpu}}
 
 Name:    %{kmod_name}-kmod
-Version: 0.0.20200205
+Version: 1.0.20200401
 Release: 1%{?dist}
 Group:   System Environment/Kernel
 License: GPLv2
@@ -65,6 +65,11 @@ done
 %{__rm} -rf %{buildroot}
 
 %changelog
+* Wed Apr 1 2020 Joe Doss <joe@solidadmin.com> 1.0.20200401-1
+- Update to 1.0.20200401
+- compat: queueing: skb_reset_redirect change has been backported to 5.[45]
+- qemu: bump default kernel to 5.5.14
+
 * Fri Feb 14 2020 Akemi Yagi <toracat@elrepo.org> - 0.0.20200205-1
 - Initial el7 build. 
 - [http://elrepo.org/bugs/view.php?id=989]

--- a/wireguard-kmod/el8/wireguard-kmod.spec
+++ b/wireguard-kmod/el8/wireguard-kmod.spec
@@ -1,5 +1,5 @@
 # Define the kmod package name here.
-%define kmod_name	wireguard	
+%define kmod_name wireguard	
 
 # If kmod_kernel_version isn't defined on the rpmbuild line, define it here.
 %{!?kmod_kernel_version: %define kmod_kernel_version 4.18.0-147.el8}
@@ -7,7 +7,7 @@
 %{!?dist: %define dist .el8}
 
 Name:		kmod-%{kmod_name}
-Version:	0.0.20200205
+Version:	1.0.20200401
 Release:	1%{?dist}
 Summary:	%{kmod_name} kernel module(s)
 Group:		System Environment/Kernel
@@ -177,5 +177,10 @@ exit 0
 %doc /usr/share/doc/kmod-%{kmod_name}-%{version}/
 
 %changelog
+* Wed Apr 1 2020 Joe Doss <joe@solidadmin.com> 1.0.20200401-1
+- Update to 1.0.20200401
+- compat: queueing: skb_reset_redirect change has been backported to 5.[45]
+- qemu: bump default kernel to 5.5.14
+
 * Sat Feb 15 2020 Akemi Yagi <toracat@elrepo.org> 0.0.20200205-1
 - Initial build for RHEL 8.1


### PR DESCRIPTION
This updates the WireGuard kmod package to 1.0.20200401.

== Changes ==

* compat: queueing: skb_reset_redirect change has been backported to 5.[45]
* qemu: bump default kernel to 5.5.14