### PR TITLE
yum-plugin-elrepo: reduce verbosity

### DIFF
--- a/yum-plugin-elrepo/elrepo.py
+++ b/yum-plugin-elrepo/elrepo.py
@@ -34,17 +34,17 @@ def exclude_hook(conduit):
     for instpkg in instpkgs:
         if instpkg.name == "kernel":
             kernels.append('kernel-modules >= ' + instpkg.version + '-' + instpkg.release + '.' + instpkg.arch)
-            conduit.info(3, '[elrepo]: found installed kernel: %s' % instpkg)
+            conduit.info(4, '[elrepo]: found installed kernel: %s' % instpkg)
 
     # get available kernels
     pkgs = conduit.getPackages()
     for pkg in pkgs:
         if pkg.name == "kernel":
             kernels.append('kernel-modules >= ' + pkg.version + '-' + pkg.release + '.' + pkg.arch)
-            conduit.info(3, '[elrepo]: found kernel: %s' % pkg)
+            conduit.info(4, '[elrepo]: found kernel: %s' % pkg)
 
     if not kernels:
-        conduit.info(2, '[elrepo]: ERROR, no kernels found')
+        conduit.info(4, '[elrepo]: ERROR, no kernels found')
         return
 
     def find_matches(kmod, requires, matchfor=None):
@@ -62,7 +62,7 @@ def exclude_hook(conduit):
                 if fnmatch.fnmatch(kernel, req):
                     return
         # else no matching kernel, excluding package
-        conduit.info(2, '[elrepo]: excluding package: %s' % kmod)
+        conduit.info(4, '[elrepo]: excluding package: %s' % kmod)
         conduit.delPackage(kmod)
 
         # if kmod-nvidia, handle matching nvidia-x11-drv packages
@@ -70,7 +70,7 @@ def exclude_hook(conduit):
             for pkg in pkgs:
                 if (pkg.name).startswith("nvidia-x11-drv"):
                     if kmod.version == pkg.version and kmod.release == pkg.release:
-                        conduit.info(2, '[elrepo]: excluding package: %s' % pkg)
+                        conduit.info(4, '[elrepo]: excluding package: %s' % pkg)
                         conduit.delPackage(pkg)
 
 

--- a/yum-plugin-elrepo/yum-plugin-elrepo.spec
+++ b/yum-plugin-elrepo/yum-plugin-elrepo.spec
@@ -1,7 +1,7 @@
 %define pluginhome /usr/lib/yum-plugins
 
 Name:    yum-plugin-elrepo
-Version: 7.5.1
+Version: 7.5.2
 Release: 1%{?dist}
 Group:   Development/Tools
 License: GPLv2
@@ -44,6 +44,9 @@ require kernels that are not yet available.
 %{pluginhome}/elrepo.pyo
 
 %changelog
+* Wed Apr 15 2020 Jason A. Donenfeld <Jason@zx2c4.com> - 7.5.2-1
+- Reduce verbosity.
+
 * Tue Nov 20 2018 Philip J Perry <phil@elrepo.org> - 7.5.1-1
 - Remove workaround for missing older kernels
 


### PR DESCRIPTION
Nobody actually wants to see elrepo's listing of every module. This
should be restricted to debug levels of verbosity. Otherwise, CentOS
users wind up with something amateurish looking, which isn't nice. It's
a shame this plugin must exist, but at least we can still make it stay
out of the way.