### PR TITLE
nvidia-x11-drv: Install systemd unit file for nvidia-persistenced on EL7 and EL8

### DIFF
--- a/nvidia-x11-drv/el7/nvidia-x11-drv.spec
+++ b/nvidia-x11-drv/el7/nvidia-x11-drv.spec
@@ -37,7 +37,8 @@ Provides:	nvidia-drivers = %{version}
 # provides desktop-file-install
 BuildRequires:	desktop-file-utils
 BuildRequires:	perl
-BuildRequires:	systemd-rpm-macros
+# For systemd_ scriptlets
+BuildRequires:	systemd
 
 Requires:	perl
 Requires:	vulkan-filesystem

--- a/nvidia-x11-drv/el7/nvidia-x11-drv.spec
+++ b/nvidia-x11-drv/el7/nvidia-x11-drv.spec
@@ -37,6 +37,7 @@ Provides:	nvidia-drivers = %{version}
 # provides desktop-file-install
 BuildRequires:	desktop-file-utils
 BuildRequires:	perl
+BuildRequires:	systemd-rpm-macros
 
 Requires:	perl
 Requires:	vulkan-filesystem
@@ -329,6 +330,14 @@ desktop-file-install \
 %{__mkdir_p} $RPM_BUILD_ROOT%{_prefix}/lib/nvidia/
 %{__install} -p -m 0644 %{SOURCE3} $RPM_BUILD_ROOT%{_prefix}/lib/nvidia/alternate-install-present
 
+# Extract and install nvidia-persistenced systemd script
+%{__tar} xf html/samples/nvidia-persistenced-init.tar.bz2
+%{__mkdir_p} $RPM_BUILD_ROOT%{_unitdir}/
+%{__install} -p -m 0644 nvidia-persistenced-init/systemd/nvidia-persistenced.service.template \
+  $RPM_BUILD_ROOT%{_unitdir}/nvidia-persistenced.service
+# Set the username for the daemon to root
+%{__sed} -i -e "s/__USER__/root/" $RPM_BUILD_ROOT%{_unitdir}/nvidia-persistenced.service
+
 popd
 
 %clean
@@ -361,6 +370,7 @@ if [ "$1" -eq "1" ]; then # new install
       done
     fi
 fi || :
+%systemd_post nvidia-persistenced.service
 
 /sbin/ldconfig
 
@@ -389,9 +399,11 @@ if [ "$1" -eq "0" ]; then # uninstall
       done
     fi
 fi ||:
+%systemd_preun nvidia-persistenced.service
 
 %postun
 /sbin/ldconfig
+%systemd_postun_with_restart nvidia-persistenced.service
 
 %postun libs
 /sbin/ldconfig
@@ -429,6 +441,7 @@ fi ||:
 %{_prefix}/lib/nvidia/alternate-install*
 %{_libdir}/xorg/modules/drivers/nvidia_drv.so
 %{_libdir}/xorg/modules/extensions/libglxserver_nvidia.*
+%{_unitdir}/nvidia-persistenced.service
 
 %files libs
 %defattr(-,root,root,-)

--- a/nvidia-x11-drv/el8/nvidia-x11-drv.spec
+++ b/nvidia-x11-drv/el8/nvidia-x11-drv.spec
@@ -34,6 +34,7 @@ Provides:	libglxserver_nvidia.so()(64bit)
 # provides desktop-file-install
 BuildRequires:	desktop-file-utils
 BuildRequires:	perl
+# For systemd_ scriptlets
 BuildRequires:	systemd-rpm-macros
 
 Requires:	perl


### PR DESCRIPTION
Notes:
- The RPMs build OK with centos+epel-7-x86_64 and centos-stream+epel-8-x86_64 but I haven't yet tested further
- Legacy drivers are not yet updated
- Changelog and release numbers are not yet updated

If this looks like a change that could be considered for merging, I'd be happy to work on updating the legacy drivers specs as well.